### PR TITLE
feat(core): CORE-3 Part A — Ellipse + Rectangle shapes (core + CPU)

### DIFF
--- a/.agent/EVIDENCE.md
+++ b/.agent/EVIDENCE.md
@@ -213,7 +213,7 @@ Part B done-gate (interactive, on a **clean** machine — verified off-`/goal`, 
 ```
 Ellipse:   score 0.23835 -> 0.02468 (10% of initial) over 60 shapes, PSNR 32.15 dB
 Rectangle: score 0.23835 -> 0.02220 ( 9% of initial) over 60 shapes, PSNR 33.07 dB
-test result: ok. 6 passed; 0 failed
+test result: ok. 7 passed; 0 failed
 ```
 Verbatim ports of fogleman's `ellipse.go` / `rectangle.go`. Three gates (the triangle-only fogleman
 parity fixture isn't extended yet — CORE-3a.2): **rasterizer geometry** hand-verified (radius-3 circle

--- a/.agent/EVIDENCE.md
+++ b/.agent/EVIDENCE.md
@@ -206,3 +206,19 @@ generated offline by `scripts/ops/gen-icon.py` (PIL only, the app's own transluc
 Part B done-gate (interactive, on a **clean** machine — verified off-`/goal`, plan §7 PKG-1):
 `xcrun stapler validate primitive.app` → "worked"; `spctl --assess --type execute primitive.app` →
 `accepted … source=Notarized Developer ID`.
+
+## CORE-3 Part A — Ellipse + Rectangle (core + CPU) (2026-06-29)
+
+### Shape support — `crates/primitive-core/tests/shapes.rs`
+```
+Ellipse:   score 0.23835 -> 0.02468 (10% of initial) over 60 shapes, PSNR 32.15 dB
+Rectangle: score 0.23835 -> 0.02220 ( 9% of initial) over 60 shapes, PSNR 33.07 dB
+test result: ok. 6 passed; 0 failed
+```
+Verbatim ports of fogleman's `ellipse.go` / `rectangle.go`. Three gates (the triangle-only fogleman
+parity fixture isn't extended yet — CORE-3a.2): **rasterizer geometry** hand-verified (radius-3 circle
+half-widths `int(sqrt(9−dy²))` = centre [2,8] / mirror [3,7]; rectangle one-span-per-row, corner-order
+invariant; edge-clamping); **determinism** byte-identical reconstruction for the same seed; **effective-
+ness** above (60 shapes ⇒ ~9–10% of the flat baseline, 32–33 dB). The CPU optimizer/model needed **zero
+changes** — `Shape::random/mutate/rasterize/svg` dispatch polymorphically. GPU kernels (CORE-3b) + GUI
+selector (CORE-3c) are the follow-ups; `triangle_coords()` panics for non-triangles until 3b.

--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -207,9 +207,10 @@ rasterize/svg), with `rasterize_ellipse` / `rasterize_rectangle` reference raste
 call `Shape::random(t, …)` / `shape.mutate/rasterize/svg` polymorphically, **the entire CPU search +
 SVG export works for the new shapes with zero changes to `optimizer.rs` / `model.rs`**.
 
-Gate evidence (all green in `make verify`; `crates/primitive-core/tests/shapes.rs`, 6 tests):
+Gate evidence (all green in `make verify`; `crates/primitive-core/tests/shapes.rs`, 7 tests):
 - **Rasterizer geometry** — hand-verified scanline spans for a radius-3 circle (`int(sqrt(9−dy²))`
-  half-widths: centre row [2,8], mirrored rows [3,7]) and a sorted-corner rectangle (one span/row);
+  half-widths: centre row [2,8], mirrored rows [3,7]), a non-circular ellipse (rx=6,ry=3 ⇒ aspect=2,
+  pins the `* aspect` term a circle would hide), and a sorted-corner rectangle (one span/row);
   edge-clamping checked.
 - **Determinism** — same seed + target ⇒ **byte-identical reconstruction** (score + `current.pix`)
   for both Ellipse and Rectangle.

--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -196,3 +196,33 @@ osx` → `target/release/bundle/osx/primitive.app` (generated Info.plist id `com
 `primitive.icns` in Resources, executable present); the script halts at the codesign boundary.
 **Part B (sign/notarize/staple) is interactive-only** — done-gate is `xcrun stapler validate` + `spctl
 --assess` = accepted on a *clean* machine (verified off-`/goal`, with you holding the Apple credentials).
+
+## CORE-3 Part A — Ellipse + Rectangle (core + CPU) — ✅ DONE (2026-06-29)
+
+The first slice of the architecture's shape-set expansion (§10 Q5: "triangle + ellipse + rect first,
+expand after PKG-1"). `core::shape` gains `Ellipse` (x,y,rx,ry) and axis-aligned `Rectangle`
+(x1,y1,x2,y2) variants — verbatim ports of fogleman's `ellipse.go` / `rectangle.go` (random/mutate/
+rasterize/svg), with `rasterize_ellipse` / `rasterize_rectangle` reference rasterizers added to
+`core::raster`. The `Shape`/`ShapeType` enums + dispatch are extended; because the optimizer/model
+call `Shape::random(t, …)` / `shape.mutate/rasterize/svg` polymorphically, **the entire CPU search +
+SVG export works for the new shapes with zero changes to `optimizer.rs` / `model.rs`**.
+
+Gate evidence (all green in `make verify`; `crates/primitive-core/tests/shapes.rs`, 6 tests):
+- **Rasterizer geometry** — hand-verified scanline spans for a radius-3 circle (`int(sqrt(9−dy²))`
+  half-widths: centre row [2,8], mirrored rows [3,7]) and a sorted-corner rectangle (one span/row);
+  edge-clamping checked.
+- **Determinism** — same seed + target ⇒ **byte-identical reconstruction** (score + `current.pix`)
+  for both Ellipse and Rectangle.
+- **Effectiveness** — 60 shapes on a 48×48 synthetic target cut the score to **~10%/9% of the
+  flat-background baseline** (PSNR 32.15 / 33.07 dB); SVG export emits valid `<ellipse>` / `<rect>`.
+
+Scope notes (carry-forward, by design):
+- **CORE-3b (GPU)**: the GPU batch path is triangle-specific (`TriangleBatch`, `score_triangles`,
+  `evolve`/`commit` all assume 6-int triangles); `Shape::triangle_coords()` **panics** for non-
+  triangles with a CORE-3b pointer. Generalizing the kernels (per-type or unified-param) is next.
+- **CORE-3c (GUI)**: a shape-type selector in the sidebar (today `runner.rs` hardcodes
+  `ShapeType::Triangle`).
+- **CORE-3a.2 (rigour)**: fogleman **bit-exact** parity for ellipse/rect needs the Go dumper
+  (`go_primitive/primitive/parity_dump_test.go`, schema is triangle-only) extended; until then the
+  three gates above pin correctness (the verbatim port + hand-checked rasters make a hidden math
+  divergence unlikely, but the fixture is the gold standard the triangles already meet).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,11 @@ core (pure) ← compute (ports) ← engine (orchestration) ← adapters / app (c
 - **CORE-1 golden** (SSIM ≥ 0.999 determinism + final score within 1% of fogleman) — `tests/golden.rs`.
 - **CORE-2 parity + CPU baseline** — `crates/primitive-engine/tests/cpu_baseline.rs` (byte-identical to core; prints shapes/sec).
 - **GPU-1/2/3** — integer-SSE parity + on-device search in `crates/primitive-gpu-cubecl/tests/*` (Metal; `make verify` runs them). The **throughput** thresholds (GPU-2 ≥20×, GPU-3 ≥460 sps) are hardware-dependent → enforced by `make perf`, not `make verify` (see `tests/common/mod.rs`); the PSNR + integer-parity gates stay in `make verify`.
+- **CORE-3 Part A** (Ellipse + Rectangle, core + CPU) — `crates/primitive-core/tests/shapes.rs` (rasterizer geometry, determinism, effectiveness). GPU kernels + GUI selector for the new shapes are CORE-3b/c; `Shape::triangle_coords()` panics for non-triangles until then.
 - **GUI-2** — the §5A interaction gates in `crates/primitive-app/tests/*` (`state_suite` pure-state matrix,
   `e2e` load→100→SVG, `forced_cpu` device chip, `a11y_tree` AccessKit, `a11y_tokens` WCAG/Reduce-Motion).
 
-Full milestone state (CORE-1/2 · GPU-1/2/3 · GUI-1/2 · PKG-1 Part A — all ✅) lives in `.agent/PROGRESS.md` + `.agent/EVIDENCE.md`.
+Full milestone state (CORE-1/2 · GPU-1/2/3 · GUI-1/2 · PKG-1 Part A · CORE-3 Part A — all ✅) lives in `.agent/PROGRESS.md` + `.agent/EVIDENCE.md`.
 
 ## Rules for changes here
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ This repository contains three implementations of the Primitive algorithm:
 
 A from-scratch Rust rewrite (hexagonal crates under [`crates/`](crates/)) that runs the whole search on the
 GPU via CubeCL→Metal with **bitwise-deterministic integer scoring**, plus a one-window `eframe` desktop app
-whose hero is the live reconstruction canvas. Triangles only for now (more shape types are a planned core
-milestone). Spec + status: [`docs/plan/primitive-2026-architecture.md`](docs/plan/primitive-2026-architecture.md),
+whose hero is the live reconstruction canvas. Shapes: triangle, ellipse, and axis-aligned rectangle on the
+CPU path (the GPU kernels + a GUI selector for ellipse/rect are the next core slice; rotated/curved variants
+follow). Spec + status: [`docs/plan/primitive-2026-architecture.md`](docs/plan/primitive-2026-architecture.md),
 [`AGENTS.md`](AGENTS.md), [`.agent/PROGRESS.md`](.agent/PROGRESS.md).
 
 ```bash

--- a/crates/primitive-core/src/lib.rs
+++ b/crates/primitive-core/src/lib.rs
@@ -46,4 +46,4 @@ pub use philox::{mulhilo, philox, rand_below, rand_u32};
 pub use raster::{rasterize_triangle_int, triangle_inside, Scanline};
 pub use rng::Rng;
 pub use score::{delta_sse_partial, difference_full, difference_partial, sse_full};
-pub use shape::{Shape, ShapeType, Triangle};
+pub use shape::{Ellipse, Rectangle, Shape, ShapeType, Triangle};

--- a/crates/primitive-core/src/raster.rs
+++ b/crates/primitive-core/src/raster.rs
@@ -15,9 +15,17 @@ pub struct Scanline {
     pub alpha: u32,
 }
 
+/// Clamp to `[lo, hi]` with fogleman's `clampInt` semantics (lower bound wins when `lo > hi`).
+/// Identical to `max(lo).min(hi)` for the `lo <= hi` inputs `crop_scanlines` always passes.
 #[inline]
 fn clamp_i32(x: i32, lo: i32, hi: i32) -> i32 {
-    x.max(lo).min(hi)
+    if x < lo {
+        lo
+    } else if x > hi {
+        hi
+    } else {
+        x
+    }
 }
 
 /// Clip scanlines to the image rectangle, dropping fully-outside runs — port of
@@ -167,7 +175,8 @@ pub fn rasterize_ellipse(
         if (y1 < 0 || y1 >= h) && (y2 < 0 || y2 >= h) {
             continue;
         }
-        let s = (((ry * ry - dy * dy) as f64).sqrt() * aspect) as i32;
+        // i64 like Go's `int`: ry can reach a canvas dimension, and ry² overflows i32 past ~46k px.
+        let s = (((ry as i64 * ry as i64 - dy as i64 * dy as i64) as f64).sqrt() * aspect) as i32;
         let mut x1 = cx - s;
         let mut x2 = cx + s;
         if x1 < 0 {

--- a/crates/primitive-core/src/raster.rs
+++ b/crates/primitive-core/src/raster.rs
@@ -146,6 +146,71 @@ fn rasterize_triangle_top(
     }
 }
 
+/// Rasterize an axis-aligned ellipse centred `(cx, cy)` with radii `(rx, ry)` into scanlines —
+/// faithful port of fogleman's `Ellipse.Rasterize`. Each row's half-width is the analytic
+/// `sqrt(ry² − dy²) · (rx/ry)`, truncated toward zero (Go's `int(...)`); x is clamped to the image
+/// and the centre row is emitted once (`dy > 0` guards the mirrored row). The caller crops for the
+/// final contract. Requires `ry ≥ 1` (guaranteed by the shape's random/mutate bounds).
+pub fn rasterize_ellipse(
+    cx: i32,
+    cy: i32,
+    rx: i32,
+    ry: i32,
+    w: i32,
+    h: i32,
+    buf: &mut Vec<Scanline>,
+) {
+    let aspect = rx as f64 / ry as f64;
+    for dy in 0..ry {
+        let y1 = cy - dy;
+        let y2 = cy + dy;
+        if (y1 < 0 || y1 >= h) && (y2 < 0 || y2 >= h) {
+            continue;
+        }
+        let s = (((ry * ry - dy * dy) as f64).sqrt() * aspect) as i32;
+        let mut x1 = cx - s;
+        let mut x2 = cx + s;
+        if x1 < 0 {
+            x1 = 0;
+        }
+        if x2 >= w {
+            x2 = w - 1;
+        }
+        if y1 >= 0 && y1 < h {
+            buf.push(Scanline {
+                y: y1,
+                x1,
+                x2,
+                alpha: 0xffff,
+            });
+        }
+        if y2 >= 0 && y2 < h && dy > 0 {
+            buf.push(Scanline {
+                y: y2,
+                x1,
+                x2,
+                alpha: 0xffff,
+            });
+        }
+    }
+}
+
+/// Rasterize an axis-aligned rectangle with inclusive opposite corners `(x1, y1)`–`(x2, y2)` (any
+/// winding; sorted internally to fogleman's `bounds()`) into one span per row — port of
+/// fogleman's `Rectangle.Rasterize`. The caller crops to the image.
+pub fn rasterize_rectangle(x1: i32, y1: i32, x2: i32, y2: i32, buf: &mut Vec<Scanline>) {
+    let (xa, xb) = if x1 <= x2 { (x1, x2) } else { (x2, x1) };
+    let (ya, yb) = if y1 <= y2 { (y1, y2) } else { (y2, y1) };
+    for y in ya..=yb {
+        buf.push(Scanline {
+            y,
+            x1: xa,
+            x2: xb,
+            alpha: 0xffff,
+        });
+    }
+}
+
 // ── Deterministic integer rasterizer (the GPU-shared path) ───────────────────────────────
 //
 // `rasterize_triangle` above is fogleman's f64 edge-walk — the *reference* raster (CORE/golden).

--- a/crates/primitive-core/src/shape.rs
+++ b/crates/primitive-core/src/shape.rs
@@ -77,9 +77,18 @@ impl Shape {
     }
 }
 
+/// Clamp to `[lo, hi]` with fogleman's `clampInt` semantics: the lower bound wins when `lo > hi`
+/// (Go checks `x < lo` first). Identical to `max(lo).min(hi)` whenever `lo <= hi` (the only case the
+/// Triangle clamps hit); the `lo > hi` branch matters only for radii clamps on a 1-px-dim canvas.
 #[inline]
 fn clamp_i32(x: i32, lo: i32, hi: i32) -> i32 {
-    x.max(lo).min(hi)
+    if x < lo {
+        lo
+    } else if x > hi {
+        hi
+    } else {
+        x
+    }
 }
 
 #[inline]
@@ -226,6 +235,8 @@ impl Ellipse {
     fn rasterize(&self, w: i32, h: i32) -> Vec<Scanline> {
         let mut buf = Vec::new();
         rasterize_ellipse(self.x, self.y, self.rx, self.ry, w, h, &mut buf);
+        // Defensive only: fogleman's Ellipse.Rasterize self-clips x and skips out-of-frame rows, so
+        // with cx/cy in-bounds (random/mutate enforce it) this crop is a no-op — kept for safety.
         crop_scanlines(&mut buf, w, h);
         buf
     }
@@ -288,6 +299,8 @@ impl Rectangle {
     fn rasterize(&self, w: i32, h: i32) -> Vec<Scanline> {
         let mut buf = Vec::new();
         rasterize_rectangle(self.x1, self.y1, self.x2, self.y2, &mut buf);
+        // Defensive only: corners are always in-bounds (random/mutate clamp), so crop is a no-op
+        // here — fogleman's Rectangle.Rasterize doesn't crop; kept for safety/consistency.
         crop_scanlines(&mut buf, w, h);
         buf
     }

--- a/crates/primitive-core/src/shape.rs
+++ b/crates/primitive-core/src/shape.rs
@@ -1,37 +1,49 @@
 //! Shapes and their geometry mutations.
 //!
-//! Port of fogleman's `Shape` family. v1 ships the `Triangle` (default mode `m=1`); the
-//! enum is the extension seam for ellipse / rect / rotated-rect (plan §10 Q5 recommends
-//! triangle + ellipse + rect by GPU-3). Geometry only — color is solved closed-form
-//! (`color.rs`), never mutated here.
+//! Port of fogleman's `Shape` family. Ships `Triangle` (default mode `m=1`), `Ellipse`, and
+//! axis-aligned `Rectangle` (plan §10 Q5: triangle + ellipse + rect first, expand after PKG-1);
+//! the enum is the extension seam for the rotated/curved variants. Geometry only — color is solved
+//! closed-form (`color.rs`), never mutated here.
 
-use crate::raster::{crop_scanlines, rasterize_triangle, Scanline};
+use crate::raster::{
+    crop_scanlines, rasterize_ellipse, rasterize_rectangle, rasterize_triangle, Scanline,
+};
 use crate::rng::Rng;
 
 /// Which primitive a search is fitting.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ShapeType {
     Triangle,
+    Ellipse,
+    Rectangle,
 }
 
 /// A geometric primitive instance.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Shape {
     Triangle(Triangle),
+    Ellipse(Ellipse),
+    Rectangle(Rectangle),
 }
 
 impl Shape {
-    /// A fresh random shape of `t`, already mutated once (matches fogleman's constructors).
+    /// A fresh random shape of `t` (Triangle is mutated once on construction, matching fogleman's
+    /// `NewRandomTriangle`; Ellipse/Rectangle are returned as-rolled, matching theirs).
     pub fn random(t: ShapeType, w: i32, h: i32, rng: &mut Rng) -> Shape {
         match t {
             ShapeType::Triangle => Shape::Triangle(Triangle::random(w, h, rng)),
+            ShapeType::Ellipse => Shape::Ellipse(Ellipse::random(w, h, rng)),
+            ShapeType::Rectangle => Shape::Rectangle(Rectangle::random(w, h, rng)),
         }
     }
 
-    /// Perturb the geometry in place, re-rolling until the shape is valid.
+    /// Perturb the geometry in place (Triangle re-rolls until valid; Ellipse/Rectangle have no
+    /// validity constraint, matching fogleman).
     pub fn mutate(&mut self, w: i32, h: i32, rng: &mut Rng) {
         match self {
             Shape::Triangle(t) => t.mutate(w, h, rng),
+            Shape::Ellipse(e) => e.mutate(w, h, rng),
+            Shape::Rectangle(r) => r.mutate(w, h, rng),
         }
     }
 
@@ -39,6 +51,8 @@ impl Shape {
     pub fn rasterize(&self, w: i32, h: i32) -> Vec<Scanline> {
         match self {
             Shape::Triangle(t) => t.rasterize(w, h),
+            Shape::Ellipse(e) => e.rasterize(w, h),
+            Shape::Rectangle(r) => r.rasterize(w, h),
         }
     }
 
@@ -46,13 +60,19 @@ impl Shape {
     pub fn svg(&self, attrs: &str) -> String {
         match self {
             Shape::Triangle(t) => t.svg(attrs),
+            Shape::Ellipse(e) => e.svg(attrs),
+            Shape::Rectangle(r) => r.svg(attrs),
         }
     }
 
     /// Flat `[x1, y1, x2, y2, x3, y3]` — the layout the GPU `score_triangles` kernel consumes.
+    /// Triangle-only: the GPU batch path is triangle-specific until CORE-3b generalizes the kernels.
     pub fn triangle_coords(&self) -> [i32; 6] {
         match self {
             Shape::Triangle(t) => [t.x1, t.y1, t.x2, t.y2, t.x3, t.y3],
+            Shape::Ellipse(_) | Shape::Rectangle(_) => {
+                panic!("triangle_coords called on a non-triangle shape; the GPU batch path is triangle-only until CORE-3b")
+            }
         }
     }
 }
@@ -164,6 +184,123 @@ impl Triangle {
         format!(
             "<polygon {} points=\"{},{} {},{} {},{}\" />",
             attrs, self.x1, self.y1, self.x2, self.y2, self.x3, self.y3
+        )
+    }
+}
+
+/// An axis-aligned ellipse: centre `(x, y)`, radii `(rx, ry)`. Port of fogleman's `Ellipse`
+/// (the non-rotated, non-circle variant). Always valid — no sliver rejection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Ellipse {
+    pub x: i32,
+    pub y: i32,
+    pub rx: i32,
+    pub ry: i32,
+}
+
+impl Ellipse {
+    fn random(w: i32, h: i32, rng: &mut Rng) -> Ellipse {
+        Ellipse {
+            x: rng.intn(w),
+            y: rng.intn(h),
+            rx: rng.intn(32) + 1,
+            ry: rng.intn(32) + 1,
+        }
+    }
+
+    fn mutate(&mut self, w: i32, h: i32, rng: &mut Rng) {
+        match rng.intn(3) {
+            0 => {
+                self.x = clamp_i32(self.x + (rng.norm() * 16.0) as i32, 0, w - 1);
+                self.y = clamp_i32(self.y + (rng.norm() * 16.0) as i32, 0, h - 1);
+            }
+            1 => {
+                self.rx = clamp_i32(self.rx + (rng.norm() * 16.0) as i32, 1, w - 1);
+            }
+            _ => {
+                self.ry = clamp_i32(self.ry + (rng.norm() * 16.0) as i32, 1, h - 1);
+            }
+        }
+    }
+
+    fn rasterize(&self, w: i32, h: i32) -> Vec<Scanline> {
+        let mut buf = Vec::new();
+        rasterize_ellipse(self.x, self.y, self.rx, self.ry, w, h, &mut buf);
+        crop_scanlines(&mut buf, w, h);
+        buf
+    }
+
+    fn svg(&self, attrs: &str) -> String {
+        format!(
+            "<ellipse {} cx=\"{}\" cy=\"{}\" rx=\"{}\" ry=\"{}\" />",
+            attrs, self.x, self.y, self.rx, self.ry
+        )
+    }
+}
+
+/// An axis-aligned rectangle with inclusive opposite corners `(x1, y1)`–`(x2, y2)`. Port of
+/// fogleman's `Rectangle`. Corners may be unsorted; `bounds`/raster/SVG normalize. Always valid.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Rectangle {
+    pub x1: i32,
+    pub y1: i32,
+    pub x2: i32,
+    pub y2: i32,
+}
+
+impl Rectangle {
+    fn random(w: i32, h: i32, rng: &mut Rng) -> Rectangle {
+        let x1 = rng.intn(w);
+        let y1 = rng.intn(h);
+        let x2 = clamp_i32(x1 + rng.intn(32) + 1, 0, w - 1);
+        let y2 = clamp_i32(y1 + rng.intn(32) + 1, 0, h - 1);
+        Rectangle { x1, y1, x2, y2 }
+    }
+
+    /// Sorted inclusive corners `(x1, y1, x2, y2)` with `x1 ≤ x2`, `y1 ≤ y2` — fogleman's `bounds`.
+    fn bounds(&self) -> (i32, i32, i32, i32) {
+        let (xa, xb) = if self.x1 <= self.x2 {
+            (self.x1, self.x2)
+        } else {
+            (self.x2, self.x1)
+        };
+        let (ya, yb) = if self.y1 <= self.y2 {
+            (self.y1, self.y2)
+        } else {
+            (self.y2, self.y1)
+        };
+        (xa, ya, xb, yb)
+    }
+
+    fn mutate(&mut self, w: i32, h: i32, rng: &mut Rng) {
+        match rng.intn(2) {
+            0 => {
+                self.x1 = clamp_i32(self.x1 + (rng.norm() * 16.0) as i32, 0, w - 1);
+                self.y1 = clamp_i32(self.y1 + (rng.norm() * 16.0) as i32, 0, h - 1);
+            }
+            _ => {
+                self.x2 = clamp_i32(self.x2 + (rng.norm() * 16.0) as i32, 0, w - 1);
+                self.y2 = clamp_i32(self.y2 + (rng.norm() * 16.0) as i32, 0, h - 1);
+            }
+        }
+    }
+
+    fn rasterize(&self, w: i32, h: i32) -> Vec<Scanline> {
+        let mut buf = Vec::new();
+        rasterize_rectangle(self.x1, self.y1, self.x2, self.y2, &mut buf);
+        crop_scanlines(&mut buf, w, h);
+        buf
+    }
+
+    fn svg(&self, attrs: &str) -> String {
+        let (xa, ya, xb, yb) = self.bounds();
+        format!(
+            "<rect {} x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" />",
+            attrs,
+            xa,
+            ya,
+            xb - xa + 1,
+            yb - ya + 1
         )
     }
 }

--- a/crates/primitive-core/tests/shapes.rs
+++ b/crates/primitive-core/tests/shapes.rs
@@ -1,0 +1,152 @@
+//! CORE-3a gate: Ellipse + Rectangle shape support (plan §10 Q5 — "triangle + ellipse + rect
+//! first, expand after PKG-1").
+//!
+//! The fogleman bit-exact parity fixture (`parity.rs` / `parity_fogleman.json`) is triangle-only;
+//! extending its Go dumper to ellipse/rect is the CORE-3a.2 follow-up. Until then, correctness of
+//! the two new shapes is pinned three ways here:
+//!   1. **rasterizer geometry** — hand-verified scanline spans for a known circle + rectangle
+//!      (these are the exact spans fogleman's `Ellipse.Rasterize` / `Rectangle.Rasterize` emit);
+//!   2. **determinism** — same seed + target ⇒ byte-identical reconstruction (the search is pure);
+//!   3. **effectiveness** — an N-shape run with each type strictly and substantially reduces the
+//!      score (the optimizer drives reconstruction end-to-end) and exports well-formed SVG.
+
+use std::collections::BTreeMap;
+
+use primitive_core::raster::{rasterize_ellipse, rasterize_rectangle, Scanline};
+use primitive_core::{Canvas, Model, Rng, ShapeType};
+
+/// Collect scanlines into a `y -> (x1, x2)` map (one span per row for these convex shapes).
+fn spans(lines: &[Scanline]) -> BTreeMap<i32, (i32, i32)> {
+    lines.iter().map(|l| (l.y, (l.x1, l.x2))).collect()
+}
+
+#[test]
+fn rectangle_rasterizes_one_span_per_row_sorted_corners() {
+    // Unsorted corners (x1>x2 here would still sort); inclusive [2,5] × [3,7] ⇒ rows 3..=7.
+    let mut buf = Vec::new();
+    rasterize_rectangle(2, 3, 5, 7, &mut buf);
+    let s = spans(&buf);
+    assert_eq!(s.len(), 5, "rows 3..=7 inclusive");
+    for y in 3..=7 {
+        assert_eq!(s[&y], (2, 5), "row {y} spans the full inclusive x range");
+    }
+
+    // Corner order must not matter (bounds() sorts): same rectangle, corners swapped.
+    let mut buf2 = Vec::new();
+    rasterize_rectangle(5, 7, 2, 3, &mut buf2);
+    assert_eq!(spans(&buf2), s, "swapped corners ⇒ identical raster");
+}
+
+#[test]
+fn ellipse_rasterizes_analytic_circle_spans() {
+    // A radius-3 circle centred at (5,5) on a 20×20 canvas. fogleman's per-row half-width is
+    // int(sqrt(9 - dy²)): dy0→3, dy1→int(2.82)=2, dy2→int(2.23)=2. So the centre row is widest.
+    let mut buf = Vec::new();
+    rasterize_ellipse(5, 5, 3, 3, 20, 20, &mut buf);
+    let s = spans(&buf);
+    assert_eq!(s.len(), 5, "rows 3..=7 (centre + two mirrored pairs)");
+    assert_eq!(s[&5], (2, 8), "centre row: half-width 3");
+    for y in [3, 4, 6, 7] {
+        assert_eq!(s[&y], (3, 7), "row {y}: half-width 2");
+    }
+}
+
+#[test]
+fn ellipse_clamps_spans_to_canvas() {
+    // Centre near the left/top edge: spans must clamp into [0, w) / drop out-of-frame rows.
+    let mut buf = Vec::new();
+    rasterize_ellipse(1, 1, 5, 5, 16, 16, &mut buf);
+    for l in &buf {
+        assert!(l.x1 >= 0 && l.x2 < 16, "x clamped into the canvas: {l:?}");
+        assert!(l.y >= 0 && l.y < 16, "y inside the canvas: {l:?}");
+        assert!(l.x1 <= l.x2, "non-empty span: {l:?}");
+    }
+}
+
+/// A synthetic, easily-reconstructable target: a two-axis gradient with a contrasting block.
+fn synthetic_target(w: usize, h: usize) -> Canvas {
+    let mut c = Canvas::new(w, h);
+    for y in 0..h {
+        for x in 0..w {
+            let i = (y * w + x) * 4;
+            c.pix[i] = (x * 255 / w) as u8;
+            c.pix[i + 1] = (y * 255 / h) as u8;
+            c.pix[i + 2] = ((x + y) * 255 / (w + h)) as u8;
+            c.pix[i + 3] = 255;
+            if (w / 4..w / 2).contains(&x) && (h / 3..2 * h / 3).contains(&y) {
+                c.pix[i] = 230;
+                c.pix[i + 1] = 40;
+                c.pix[i + 2] = 90;
+            }
+        }
+    }
+    c
+}
+
+fn run(t: ShapeType, seed: u64, count: i32) -> Model {
+    let mut model = Model::with_average_background(synthetic_target(48, 48));
+    let mut rng = Rng::new(seed);
+    model.run(t, 128, count, &mut rng);
+    model
+}
+
+#[test]
+fn ellipse_and_rectangle_runs_are_deterministic() {
+    for t in [ShapeType::Ellipse, ShapeType::Rectangle] {
+        let a = run(t, 7, 40);
+        let b = run(t, 7, 40);
+        assert_eq!(a.score, b.score, "{t:?}: same seed ⇒ identical score");
+        assert_eq!(
+            a.current.pix, b.current.pix,
+            "{t:?}: same seed ⇒ byte-identical reconstruction"
+        );
+        assert_eq!(a.shapes.len(), b.shapes.len());
+    }
+}
+
+#[test]
+fn ellipse_and_rectangle_reconstruct_the_target() {
+    const COUNT: i32 = 60;
+    for t in [ShapeType::Ellipse, ShapeType::Rectangle] {
+        let initial = Model::with_average_background(synthetic_target(48, 48)).score;
+        let model = run(t, 1, COUNT);
+        println!(
+            "{t:?}: score {initial:.5} -> {:.5} ({:.0}% of initial) over {COUNT} shapes, PSNR {:.2} dB",
+            model.score,
+            model.score / initial * 100.0,
+            model.psnr()
+        );
+        // The hill-climb only ever accepts a strictly-improving shape, so the score is monotone;
+        // a real reconstruction cuts it well below the flat-background baseline.
+        assert_eq!(
+            model.shapes.len(),
+            COUNT as usize,
+            "{t:?}: every shape added"
+        );
+        assert!(
+            model.score < initial * 0.6,
+            "{t:?}: {COUNT} shapes should cut the score to <60% of the flat baseline (got {:.1}%)",
+            model.score / initial * 100.0
+        );
+    }
+}
+
+#[test]
+fn ellipse_and_rectangle_export_valid_svg() {
+    let e = run(ShapeType::Ellipse, 3, 10).svg();
+    assert!(
+        e.contains("<ellipse "),
+        "ellipse run emits <ellipse> elements"
+    );
+    assert!(
+        e.contains("<svg") && e.contains("</svg>"),
+        "well-formed SVG root"
+    );
+
+    let r = run(ShapeType::Rectangle, 3, 10).svg();
+    assert!(r.contains("<rect "), "rectangle run emits <rect> elements");
+    assert!(
+        r.contains("<svg") && r.contains("</svg>"),
+        "well-formed SVG root"
+    );
+}

--- a/crates/primitive-core/tests/shapes.rs
+++ b/crates/primitive-core/tests/shapes.rs
@@ -52,6 +52,23 @@ fn ellipse_rasterizes_analytic_circle_spans() {
 }
 
 #[test]
+fn ellipse_rasterizes_aspect_ratio_spans() {
+    // rx ≠ ry pins the `* aspect` term (a circle's aspect == 1 hides bugs in it). Centre (8,8),
+    // rx=6, ry=3 ⇒ aspect=2, half-width = int(sqrt(9−dy²) · 2):
+    //   dy0 → int(3·2)=6 → row 8 = [2,14];  dy1 → int(2.828·2)=5 → rows 7,9 = [3,13];
+    //   dy2 → int(2.236·2)=4 → rows 6,10 = [4,12].
+    let mut buf = Vec::new();
+    rasterize_ellipse(8, 8, 6, 3, 20, 20, &mut buf);
+    let s = spans(&buf);
+    assert_eq!(s.len(), 5, "rows 6..=10");
+    assert_eq!(s[&8], (2, 14), "centre row: half-width int(3·2)=6");
+    assert_eq!(s[&7], (3, 13), "dy=1: half-width int(sqrt(8)·2)=5");
+    assert_eq!(s[&9], (3, 13));
+    assert_eq!(s[&6], (4, 12), "dy=2: half-width int(sqrt(5)·2)=4");
+    assert_eq!(s[&10], (4, 12));
+}
+
+#[test]
 fn ellipse_clamps_spans_to_canvas() {
     // Centre near the left/top edge: spans must clamp into [0, w) / drop out-of-frame rows.
     let mut buf = Vec::new();


### PR DESCRIPTION
## Summary

First slice of the architecture's shape-set expansion (§10 Q5: *"triangle + ellipse + rect first, expand after PKG-1"*). Adds **Ellipse** and axis-aligned **Rectangle** to the pure core + CPU search path — verbatim ports of fogleman's `ellipse.go` / `rectangle.go`.

Because the optimizer/model call `Shape::random(t, …)` / `mutate` / `rasterize` / `svg` polymorphically, **the entire CPU search + SVG export works for the new shapes with zero changes to `optimizer.rs` / `model.rs`** — the change is purely additive in `core::shape` + `core::raster`.

## What's in

- `core::shape`: `Ellipse {x,y,rx,ry}` + `Rectangle {x1,y1,x2,y2}` variants; `ShapeType`/`Shape` enums + dispatch extended.
- `core::raster`: `rasterize_ellipse` (analytic per-row `sqrt` span) + `rasterize_rectangle` (one span/row) reference rasterizers.

## Gate — `crates/primitive-core/tests/shapes.rs` (6 tests, green in `make verify`)

- **Rasterizer geometry** — hand-verified scanline spans (radius-3 circle half-widths `int(sqrt(9−dy²))`: centre `[2,8]`, mirror `[3,7]`; sorted-corner rectangle one-span-per-row; edge-clamping).
- **Determinism** — same seed ⇒ **byte-identical reconstruction** (score + `current.pix`) for both shapes.
- **Effectiveness** — 60 shapes on a 48×48 synthetic target cut the score to **~10% / 9%** of the flat baseline (PSNR **32.15 / 33.07 dB**); valid `<ellipse>` / `<rect>` SVG.

## Follow-ups (scoped out by design)

- **CORE-3b (GPU)** — `TriangleBatch` / `score_triangles` / `evolve` / `commit` are 6-int triangle-specific; `Shape::triangle_coords()` panics for non-triangles until the kernels are generalized.
- **CORE-3c (GUI)** — shape-type selector (today `runner.rs` hardcodes `ShapeType::Triangle`).
- **CORE-3a.2** — extend the triangle-only fogleman parity fixture for bit-exact ellipse/rect (the three gates above pin correctness meanwhile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)