### PR TITLE
feat(core): CORE-3 Part B.1 — integer ellipse/rect rasterizers (GPU-shared path)

### DIFF
--- a/.agent/EVIDENCE.md
+++ b/.agent/EVIDENCE.md
@@ -244,13 +244,16 @@ Visual check is the headless egui_kittest render (a11y_tree) — the native-app 
 ```
 ellipse_inside_matches_implicit_test ............................ ok  (centre+extrema in, 1-past out)
 int_ellipse_raster_is_contiguous_inside_and_symmetric ........... ok  (span centred on cx, vert-symmetric)
-int_ellipse_roughly_matches_f64_reference ....................... ok  (within 8% of fogleman f64 area)
-int_rect_raster_clamps_and_spans_corner_order_invariant ......... ok  (cropped, corner-order invariant)
+int_ellipse_matches_f64_reference_per_row ....................... ok  (per-row width ≤2px vs f64, area ≤8%)
+int_rect_raster_clamps_and_spans_corner_order_invariant ......... ok  (cropped; off-canvas drops, no phantom col)
 int_ellipse_raster_is_deterministic / int_raster_* (triangle) ... ok  (byte-identical)
-make verify ..................................................... verify: ALL GREEN  (raster.rs 222 / raster_int.rs 297 LOC, both < 500)
+make verify ..................................................... verify: ALL GREEN  (raster.rs 222 / raster_int.rs 322 LOC, both < 500)
 ```
-`ellipse_inside` = integer implicit test `ry²·dx² + rx²·dy² ≤ rx²·ry²` (i64; GPU mirrors in i32 within the
-≤128-px bound, §6.6). `rasterize_ellipse_int` bbox-scans the per-row contiguous run (convex);
-`rasterize_rectangle_int` is the self-cropping integer bbox. **Refactor:** the additions took `raster.rs`
-to 516 LOC (> 500 gate), so the integer rasterizers split into `raster_int.rs` (f64 golden reference stays
-in `raster.rs`); `clamp_i32` is `pub(crate)`-shared. Not yet GPU-wired — CORE-3b.2 consumes these on-device.
+`ellipse_inside` = integer implicit test `ry²·dx² + rx²·dy² ≤ rx²·ry²` (i64; the i32 GPU mirror is
+overflow-free only while operands stay ≲ **181** — a degree-4 product, *not* the ~46k of a single `ry²`;
+the ≤128-px GPU canvas keeps the peak `2·128⁴ ≈ 5.4e8` ~4× under i32::MAX, §6.6, with a `debug_assert`
+guarding the domain). `rasterize_ellipse_int` bbox-scans the per-row contiguous run (convex);
+`rasterize_rectangle_int` is the self-cropping integer bbox (off-canvas rects **drop**, matching the f64
+crop, rather than saturating into a phantom column). **Refactor:** the additions took `raster.rs` to 516
+LOC (> 500 gate), so the integer rasterizers split into `raster_int.rs` (f64 golden reference stays in
+`raster.rs`); `clamp_i32` is `pub(crate)`-shared. Not yet GPU-wired — CORE-3b.2 consumes these on-device.

--- a/.agent/EVIDENCE.md
+++ b/.agent/EVIDENCE.md
@@ -237,3 +237,20 @@ Sidebar `selectable_value` (△ triangle · ◯ ellipse · ▭ rect) → persist
 core (pure-by-default) for persistence; `#[serde(default)]` keeps old saved params loading. `runner::start`
 routes non-triangle shapes to the CPU path even on a GPU device (GPU instant is triangle-only until 3b).
 Visual check is the headless egui_kittest render (a11y_tree) — the native-app stand-in for a screenshot.
+
+## CORE-3 Part B.1 — integer ellipse/rect rasterizers (2026-06-29)
+
+### GPU-shared integer rasterizers — `crates/primitive-core/src/raster_int.rs` (new module)
+```
+ellipse_inside_matches_implicit_test ............................ ok  (centre+extrema in, 1-past out)
+int_ellipse_raster_is_contiguous_inside_and_symmetric ........... ok  (span centred on cx, vert-symmetric)
+int_ellipse_roughly_matches_f64_reference ....................... ok  (within 8% of fogleman f64 area)
+int_rect_raster_clamps_and_spans_corner_order_invariant ......... ok  (cropped, corner-order invariant)
+int_ellipse_raster_is_deterministic / int_raster_* (triangle) ... ok  (byte-identical)
+make verify ..................................................... verify: ALL GREEN  (raster.rs 222 / raster_int.rs 297 LOC, both < 500)
+```
+`ellipse_inside` = integer implicit test `ry²·dx² + rx²·dy² ≤ rx²·ry²` (i64; GPU mirrors in i32 within the
+≤128-px bound, §6.6). `rasterize_ellipse_int` bbox-scans the per-row contiguous run (convex);
+`rasterize_rectangle_int` is the self-cropping integer bbox. **Refactor:** the additions took `raster.rs`
+to 516 LOC (> 500 gate), so the integer rasterizers split into `raster_int.rs` (f64 golden reference stays
+in `raster.rs`); `clamp_i32` is `pub(crate)`-shared. Not yet GPU-wired — CORE-3b.2 consumes these on-device.

--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -218,9 +218,12 @@ Gate evidence (all green in `make verify`; `crates/primitive-core/tests/shapes.r
   flat-background baseline** (PSNR 32.15 / 33.07 dB); SVG export emits valid `<ellipse>` / `<rect>`.
 
 Scope notes (carry-forward, by design):
-- **CORE-3b (GPU)**: the GPU batch path is triangle-specific (`TriangleBatch`, `score_triangles`,
-  `evolve`/`commit` all assume 6-int triangles); `Shape::triangle_coords()` **panics** for non-
-  triangles with a CORE-3b pointer. Generalizing the kernels (per-type or unified-param) is next.
+- **CORE-3b (GPU)**: staged in three. **3b.1 (integer rasterizers) ✅ DONE** — see the Part B.1
+  section below. **3b.2/3b.3 remain**: the GPU batch path is still triangle-specific (`TriangleBatch`,
+  `score_triangles`, `evolve`/`commit` all assume 6-int triangles); `Shape::triangle_coords()`
+  **panics** for non-triangles with a CORE-3b pointer. 3b.2 = generalize the score kernel to consume
+  `rasterize_ellipse_int`/`rasterize_rectangle_int` with GPU↔CPU parity; 3b.3 = generalize
+  `evolve`/`commit` (in-kernel random/mutate per shape type).
 - **CORE-3c (GUI)**: ✅ DONE — see the Part C section below.
 - **CORE-3a.2 (rigour)**: fogleman **bit-exact** parity for ellipse/rect needs the Go dumper
   (`go_primitive/primitive/parity_dump_test.go`, schema is triangle-only) extended; until then the
@@ -255,3 +258,37 @@ Gate evidence (all green in `make verify`):
 Carry-forward: GPU instant mode for ellipse/rect is CORE-3b. The device chip still reads `Metal` when a
 non-triangle run is silently on CPU — cosmetic (the chip is GPU *availability*, not active backend);
 revisit if it confuses.
+
+## CORE-3 Part B.1 — integer ellipse/rect rasterizers (GPU-shared path) — ✅ DONE (2026-06-29)
+
+The foundation for the GPU shape-set expansion: the §6.6 integer rasterizers ellipse/rect need so the
+GPU kernel and its CPU oracle cover the **exact same pixels** (Metal has no f64). Mirrors the existing
+triangle path (`rasterize_triangle_int` / `triangle_inside`):
+
+- **`ellipse_inside(cx, cy, rx, ry, px, py)`** — the integer implicit test `ry²·dx² + rx²·dy² ≤ rx²·ry²`
+  (no `sqrt`; the integer analogue of `triangle_inside`). Computed in `i64`: `ry²·dx²` overflows `i32`
+  past ~46k px, so the GPU mirror (i32) is valid within the documented canvas bound (≤128 px, §6.6),
+  where the two agree bit-for-bit (no overflow).
+- **`rasterize_ellipse_int`** — bbox-scan emitting the per-row contiguous run (ellipses are convex), the
+  integer counterpart of fogleman's f64 `rasterize_ellipse`.
+- **`rasterize_rectangle_int`** — self-cropping integer bbox (already all-integer; trivial GPU mirror).
+
+**Refactor (size gate, not allowlist):** adding these pushed `raster.rs` to 516 LOC (> 500 hard gate),
+so the integer rasterizers split into a new **`raster_int.rs`** module — the seam the file's own comment
+already drew (f64 golden reference in `raster.rs` ← → integer GPU-shared path in `raster_int.rs`). Both
+files now ~220–290 LOC. `clamp_i32` is `pub(crate)` so both share one clamp.
+
+Gate evidence (all green in `make verify`; `crates/primitive-core/src/raster_int.rs` tests, 7 total):
+- **`ellipse_inside_matches_implicit_test`** — centre + 4 axis extrema inside/on-boundary; one step past
+  each axis and the bbox corner are outside.
+- **`int_ellipse_raster_is_contiguous_inside_and_symmetric`** — every emitted pixel inside, maximal run,
+  each row's span centred on `cx` (`x1+x2 == 2·cx`), vertical symmetry (`cy−k`/`cy+k` identical).
+- **`int_ellipse_roughly_matches_f64_reference`** — integer raster covers within **8%** of fogleman's f64
+  scanline area (sub-pixel edges differ, as for triangles).
+- **`int_rect_raster_clamps_and_spans_corner_order_invariant`** — full-width span/row, corner-order
+  invariant, cropped to the image (never out of bounds).
+- determinism (ellipse + the carried-over triangle int tests) byte-identical.
+
+Carry-forward: these are **not yet GPU-wired** — CORE-3b.2 generalizes the score kernel to consume them
+on-device with GPU↔CPU bit-identical parity (like GPU-2 for triangles), then 3b.3 the `evolve`/`commit`
+search loop.

--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -283,12 +283,15 @@ Gate evidence (all green in `make verify`; `crates/primitive-core/src/raster_int
   each axis and the bbox corner are outside.
 - **`int_ellipse_raster_is_contiguous_inside_and_symmetric`** — every emitted pixel inside, maximal run,
   each row's span centred on `cx` (`x1+x2 == 2·cx`), vertical symmetry (`cy−k`/`cy+k` identical).
-- **`int_ellipse_roughly_matches_f64_reference`** — integer raster covers within **8%** of fogleman's f64
-  scanline area (sub-pixel edges differ, as for triangles).
+- **`int_ellipse_matches_f64_reference_per_row`** — per-row span widths agree with fogleman's f64 raster
+  to ≤ 2px (a real shape oracle: total-area alone can't catch a shifted/distorted ellipse), ≤ 2 extreme
+  rows of coverage mismatch, total area within 8%.
 - **`int_rect_raster_clamps_and_spans_corner_order_invariant`** — full-width span/row, corner-order
   invariant, cropped to the image (never out of bounds).
 - determinism (ellipse + the carried-over triangle int tests) byte-identical.
 
 Carry-forward: these are **not yet GPU-wired** — CORE-3b.2 generalizes the score kernel to consume them
 on-device with GPU↔CPU bit-identical parity (like GPU-2 for triangles), then 3b.3 the `evolve`/`commit`
-search loop.
+search loop. Minor debt (review NIT, deferred to avoid a rename-only change): `shape.rs` has a private
+`clamp_i32` byte-identical to `raster.rs`'s now-`pub(crate)` one — fold the duplicate into the next
+`shape.rs` touch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,11 +44,12 @@ core (pure) ← compute (ports) ← engine (orchestration) ← adapters / app (c
 - **CORE-2 parity + CPU baseline** — `crates/primitive-engine/tests/cpu_baseline.rs` (byte-identical to core; prints shapes/sec).
 - **GPU-1/2/3** — integer-SSE parity + on-device search in `crates/primitive-gpu-cubecl/tests/*` (Metal; `make verify` runs them). The **throughput** thresholds (GPU-2 ≥20×, GPU-3 ≥460 sps) are hardware-dependent → enforced by `make perf`, not `make verify` (see `tests/common/mod.rs`); the PSNR + integer-parity gates stay in `make verify`.
 - **CORE-3 Part A** (Ellipse + Rectangle, core + CPU) — `crates/primitive-core/tests/shapes.rs` (rasterizer geometry, determinism, effectiveness). `Shape::triangle_coords()` panics for non-triangles until the GPU kernels generalize (CORE-3b).
+- **CORE-3 Part B.1** (integer ellipse/rect rasterizers, the GPU-shared §6.6 path) — `crates/primitive-core/src/raster_int.rs` (new module; f64 golden reference stays in `raster.rs`). `ellipse_inside` = integer implicit test `ry²·dx²+rx²·dy² ≤ rx²·ry²`; `rasterize_ellipse_int`/`rasterize_rectangle_int`. Not yet GPU-wired (CORE-3b.2).
 - **CORE-3 Part C** (GUI shape selector) — `crates/primitive-app/tests/e2e.rs` (ellipse run → `<ellipse>` SVG), `runner::tests` (pure `should_use_gpu` routing guard), `a11y_tree.rs` (all three options in the AccessKit tree + click mutates selection). `ShapeType` is selectable + persisted; GPU instant mode stays triangle-only (CORE-3b).
 - **GUI-2** — the §5A interaction gates in `crates/primitive-app/tests/*` (`state_suite` pure-state matrix,
   `e2e` load→100→SVG, `forced_cpu` device chip, `a11y_tree` AccessKit, `a11y_tokens` WCAG/Reduce-Motion).
 
-Full milestone state (CORE-1/2 · GPU-1/2/3 · GUI-1/2 · PKG-1 Part A · CORE-3 Part A+C — all ✅) lives in `.agent/PROGRESS.md` + `.agent/EVIDENCE.md`.
+Full milestone state (CORE-1/2 · GPU-1/2/3 · GUI-1/2 · PKG-1 Part A · CORE-3 Part A+B.1+C — all ✅) lives in `.agent/PROGRESS.md` + `.agent/EVIDENCE.md`.
 
 ## Rules for changes here
 

--- a/crates/primitive-core/src/lib.rs
+++ b/crates/primitive-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod model;
 pub mod optimizer;
 pub mod philox;
 pub mod raster;
+pub mod raster_int;
 pub mod rng;
 pub mod score;
 pub mod shape;
@@ -43,7 +44,11 @@ pub use eval::candidate_color_and_delta;
 pub use model::{psnr_from_score, AddedShape, Model};
 pub use optimizer::{Ctx, SearchBudget, Searcher, State};
 pub use philox::{mulhilo, philox, rand_below, rand_u32};
-pub use raster::{rasterize_triangle_int, triangle_inside, Scanline};
+pub use raster::Scanline;
+pub use raster_int::{
+    ellipse_inside, rasterize_ellipse_int, rasterize_rectangle_int, rasterize_triangle_int,
+    triangle_inside,
+};
 pub use rng::Rng;
 pub use score::{delta_sse_partial, difference_full, difference_partial, sse_full};
 pub use shape::{Ellipse, Rectangle, Shape, ShapeType, Triangle};

--- a/crates/primitive-core/src/raster.rs
+++ b/crates/primitive-core/src/raster.rs
@@ -17,8 +17,9 @@ pub struct Scanline {
 
 /// Clamp to `[lo, hi]` with fogleman's `clampInt` semantics (lower bound wins when `lo > hi`).
 /// Identical to `max(lo).min(hi)` for the `lo <= hi` inputs `crop_scanlines` always passes.
+/// `pub(crate)` so the integer rasterizers in [`crate::raster_int`] share this one clamp.
 #[inline]
-fn clamp_i32(x: i32, lo: i32, hi: i32) -> i32 {
+pub(crate) fn clamp_i32(x: i32, lo: i32, hi: i32) -> i32 {
     if x < lo {
         lo
     } else if x > hi {
@@ -217,96 +218,5 @@ pub fn rasterize_rectangle(x1: i32, y1: i32, x2: i32, y2: i32, buf: &mut Vec<Sca
             x2: xb,
             alpha: 0xffff,
         });
-    }
-}
-
-// ── Deterministic integer rasterizer (the GPU-shared path) ───────────────────────────────
-//
-// `rasterize_triangle` above is fogleman's f64 edge-walk — the *reference* raster (CORE/golden).
-// Metal has no f64, so the GPU path uses the integer edge-function rasterizer below instead:
-// pure i32 arithmetic, trivially identical on CPU and GPU (no float rounding to diverge on), so
-// the GPU and its CPU oracle cover the exact same pixels (plan §6.6). Coverage differs from the
-// f64 reference by sub-pixel edges — that is expected and fine; this is the deterministic
-// production path, the f64 one stays the historical reference.
-
-/// Twice the signed area of triangle `(a, b, p)` — the integer edge function. Inside a triangle,
-/// all three edge functions share one sign (positive for CCW, negative for CW).
-#[inline]
-pub fn edge(ax: i32, ay: i32, bx: i32, by: i32, px: i32, py: i32) -> i32 {
-    (bx - ax) * (py - ay) - (by - ay) * (px - ax)
-}
-
-/// Is pixel `(px, py)` inside (or on the boundary of) the triangle? Integer, winding-agnostic.
-#[inline]
-pub fn triangle_inside(t: [i32; 6], px: i32, py: i32) -> bool {
-    let e0 = edge(t[0], t[1], t[2], t[3], px, py);
-    let e1 = edge(t[2], t[3], t[4], t[5], px, py);
-    let e2 = edge(t[4], t[5], t[0], t[1], px, py);
-    (e0 >= 0 && e1 >= 0 && e2 >= 0) || (e0 <= 0 && e1 <= 0 && e2 <= 0)
-}
-
-/// Deterministic integer rasterization of a triangle into cropped scanlines.
-///
-/// Scans the clamped bounding box and emits, per row, the contiguous covered run (valid
-/// triangles are convex, so inside pixels on a row are contiguous). This is the rasterizer the
-/// GPU kernel reproduces pixel-for-pixel.
-pub fn rasterize_triangle_int(t: [i32; 6], w: i32, h: i32, buf: &mut Vec<Scanline>) {
-    let xmin = clamp_i32(t[0].min(t[2]).min(t[4]), 0, w - 1);
-    let xmax = clamp_i32(t[0].max(t[2]).max(t[4]), 0, w - 1);
-    let ymin = clamp_i32(t[1].min(t[3]).min(t[5]), 0, h - 1);
-    let ymax = clamp_i32(t[1].max(t[3]).max(t[5]), 0, h - 1);
-    for py in ymin..=ymax {
-        let mut lo = -1;
-        let mut hi = -1;
-        for px in xmin..=xmax {
-            if triangle_inside(t, px, py) {
-                if lo < 0 {
-                    lo = px;
-                }
-                hi = px;
-            }
-        }
-        if lo >= 0 {
-            buf.push(Scanline {
-                y: py,
-                x1: lo,
-                x2: hi,
-                alpha: 0xffff,
-            });
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn int_raster_coverage_is_contiguous_and_inside() {
-        let t = [2, 2, 30, 6, 10, 28];
-        let mut buf = Vec::new();
-        rasterize_triangle_int(t, 32, 32, &mut buf);
-        assert!(!buf.is_empty());
-        for s in &buf {
-            assert!(s.x1 <= s.x2);
-            // every pixel in the emitted run is actually inside
-            for x in s.x1..=s.x2 {
-                assert!(triangle_inside(t, x, s.y), "({x},{}) not inside", s.y);
-            }
-            // the pixel just left of the run is outside (run is the maximal inside span)
-            if s.x1 > 0 {
-                assert!(!triangle_inside(t, s.x1 - 1, s.y));
-            }
-        }
-    }
-
-    #[test]
-    fn int_raster_is_deterministic() {
-        let t = [1, 0, 20, 5, 7, 19];
-        let mut a = Vec::new();
-        let mut b = Vec::new();
-        rasterize_triangle_int(t, 24, 24, &mut a);
-        rasterize_triangle_int(t, 24, 24, &mut b);
-        assert_eq!(a, b);
     }
 }

--- a/crates/primitive-core/src/raster_int.rs
+++ b/crates/primitive-core/src/raster_int.rs
@@ -60,9 +60,15 @@ pub fn rasterize_triangle_int(t: [i32; 6], w: i32, h: i32, buf: &mut Vec<Scanlin
 /// Is pixel `(px, py)` inside (or on the boundary of) the axis-aligned ellipse centred `(cx, cy)`
 /// with radii `(rx, ry)`? The integer implicit test `ry²·dx² + rx²·dy² ≤ rx²·ry²` — no `sqrt`, so
 /// it's trivially identical on CPU and GPU (the integer analogue of [`triangle_inside`]). Squaring
-/// makes the sign of `rx`/`ry` irrelevant. Computed in `i64`: `ry²·dx²` overflows `i32` past ~46k px,
-/// so the GPU mirror (i32) is valid only within the documented canvas bound (§6.6), where the two
-/// agree bit-for-bit because no overflow occurs.
+/// makes the sign of `rx`/`ry` irrelevant. Computed in `i64`.
+///
+/// **i32-mirror overflow domain.** Each term `ry·ry·dx·dx` is a **degree-4** product, so the i32 GPU
+/// mirror is overflow-free only while every operand stays ≲ **181** (`2·n⁴ < i32::MAX` at `n ≈ 181`) —
+/// **not** the `~46k` of a single `ry²` (that is the f64 path's bound, `raster.rs`). The ≤128-px GPU
+/// canvas (`runner.rs` `GPU_INSTANT_MAX`), with radii clamped to `w-1`/`h-1`, keeps the peak at
+/// `2·128⁴ ≈ 5.4e8` — ~4× under i32::MAX — so CPU-i64 and GPU-i32 agree bit-for-bit there. Raising the
+/// canvas cap past ~181 px would silently diverge the GPU; see the `debug_assert` in
+/// [`rasterize_ellipse_int`].
 #[inline]
 pub fn ellipse_inside(cx: i32, cy: i32, rx: i32, ry: i32, px: i32, py: i32) -> bool {
     let dx = (px - cx) as i64;
@@ -85,6 +91,13 @@ pub fn rasterize_ellipse_int(
     buf: &mut Vec<Scanline>,
 ) {
     let (rx, ry) = (rx.abs(), ry.abs());
+    // The i32 GPU mirror overflows once an operand exceeds ~181 (degree-4 product, see
+    // `ellipse_inside`); the ≤128-px GPU canvas keeps us ~4× clear. CPU is i64 so this never overflows
+    // *here* — the assert flags a too-large ellipse that would diverge the GPU before it ships.
+    debug_assert!(
+        rx < 182 && ry < 182,
+        "rasterize_ellipse_int: rx/ry ≥ 182 overflows the i32 GPU mirror (§6.6)"
+    );
     let xmin = clamp_i32(cx - rx, 0, w - 1);
     let xmax = clamp_i32(cx + rx, 0, w - 1);
     let ymin = clamp_i32(cy - ry, 0, h - 1);
@@ -124,10 +137,19 @@ pub fn rasterize_rectangle_int(
     h: i32,
     buf: &mut Vec<Scanline>,
 ) {
-    let xlo = clamp_i32(x1.min(x2), 0, w - 1);
-    let xhi = clamp_i32(x1.max(x2), 0, w - 1);
-    let ylo = clamp_i32(y1.min(y2), 0, h - 1);
-    let yhi = clamp_i32(y1.max(y2), 0, h - 1);
+    let (xa, xb) = (x1.min(x2), x1.max(x2));
+    let (ya, yb) = (y1.min(y2), y1.max(y2));
+    // Fully off-canvas → emit nothing, matching the f64 reference's crop (`crop_scanlines` drops a
+    // run with `x1 >= w` / `x2 < 0`) instead of saturating `clamp_i32` into a phantom 1-px edge
+    // column. Production never feeds an off-canvas rect (corners are clamped in `Rectangle`), so this
+    // only hardens the degenerate case; in-bounds rects are unaffected.
+    if xb < 0 || xa >= w || yb < 0 || ya >= h {
+        return;
+    }
+    let xlo = clamp_i32(xa, 0, w - 1);
+    let xhi = clamp_i32(xb, 0, w - 1);
+    let ylo = clamp_i32(ya, 0, h - 1);
+    let yhi = clamp_i32(yb, 0, h - 1);
     for py in ylo..=yhi {
         buf.push(Scanline {
             y: py,
@@ -274,24 +296,50 @@ mod tests {
             assert_eq!((s.x1, s.x2), (0, 5), "x clamped to [0, 5]");
             assert!(s.y >= 0 && s.y < 10);
         }
+        // a rect fully off the right edge emits nothing — drops like the f64 reference, no phantom
+        // 1-px column at x=w-1 (the saturating-clamp divergence the review flagged).
+        let mut offscreen = Vec::new();
+        rasterize_rectangle_int(200, 0, 200, 5, 10, 10, &mut offscreen);
+        assert!(
+            offscreen.is_empty(),
+            "fully off-canvas rect drops, no phantom edge column"
+        );
     }
 
     #[test]
-    fn int_ellipse_roughly_matches_f64_reference() {
-        // the integer implicit test and fogleman's f64 scanline raster cover nearly the same pixels
-        // (sub-pixel edges differ, as for triangles); assert the covered-pixel counts agree to ≤ 8%.
+    fn int_ellipse_matches_f64_reference_per_row() {
+        // A real shape oracle (not just total area — that can't distinguish a shifted/distorted
+        // ellipse with the same pixel count): the integer raster and fogleman's f64 scanline raster
+        // agree on each row's span width to ≤ 2px (sub-pixel edges differ, as for triangles), and
+        // disagree on whether a row is covered for at most the 2 extreme rows (the integer test
+        // includes the single centre-column pixel at `cy ± ry` that fogleman's `dy in 0..ry` loop
+        // stops just short of). Total area within ≤ 8% as a coarse backstop.
         let (cx, cy, rx, ry) = (24, 24, 14, 9);
-        let mut iref = Vec::new();
-        rasterize_ellipse(cx, cy, rx, ry, 50, 50, &mut iref);
+        let mut fref = Vec::new();
+        rasterize_ellipse(cx, cy, rx, ry, 50, 50, &mut fref);
         let mut iint = Vec::new();
         rasterize_ellipse_int(cx, cy, rx, ry, 50, 50, &mut iint);
-        let area = |b: &[Scanline]| b.iter().map(|s| (s.x2 - s.x1 + 1) as i64).sum::<i64>();
-        let (fa, ia) = (area(&iref), area(&iint));
-        let diff = (fa - ia).abs() as f64 / fa as f64;
+        let width = |b: &[Scanline], y: i32| b.iter().find(|s| s.y == y).map(|s| s.x2 - s.x1 + 1);
+        let mut coverage_mismatches = 0;
+        for y in (cy - ry)..=(cy + ry) {
+            match (width(&fref, y), width(&iint, y)) {
+                (Some(fw), Some(iw)) => assert!(
+                    (fw - iw).abs() <= 2,
+                    "row {y}: f64 width {fw} vs int width {iw} differ > 2px"
+                ),
+                (None, None) => {}
+                _ => coverage_mismatches += 1,
+            }
+        }
         assert!(
-            diff <= 0.08,
-            "int ellipse area {ia} vs f64 {fa} differ {:.1}%",
-            diff * 100.0
+            coverage_mismatches <= 2,
+            "rasters disagree on coverage for {coverage_mismatches} rows (> 2 extreme rows)"
+        );
+        let area = |b: &[Scanline]| b.iter().map(|s| (s.x2 - s.x1 + 1) as i64).sum::<i64>();
+        let (fa, ia) = (area(&fref), area(&iint));
+        assert!(
+            (fa - ia).abs() as f64 / fa as f64 <= 0.08,
+            "int ellipse area {ia} vs f64 {fa} differ > 8%"
         );
     }
 }

--- a/crates/primitive-core/src/raster_int.rs
+++ b/crates/primitive-core/src/raster_int.rs
@@ -1,0 +1,297 @@
+//! Deterministic integer rasterizers — the GPU-shared path (plan §6.6).
+//!
+//! [`crate::raster`] holds fogleman's f64 edge-walk rasterizers (the CORE/golden *reference*).
+//! Metal has no f64, so the GPU path uses the integer rasterizers here instead: pure integer
+//! arithmetic, trivially identical on CPU and GPU (no float rounding to diverge on), so the GPU and
+//! its CPU oracle cover the exact same pixels. Coverage differs from the f64 reference by sub-pixel
+//! edges — expected and fine; this is the deterministic production path, the f64 one stays the
+//! historical reference. Each kernel in `primitive-gpu-cubecl` mirrors one function here.
+
+use crate::raster::{clamp_i32, Scanline};
+
+/// Twice the signed area of triangle `(a, b, p)` — the integer edge function. Inside a triangle,
+/// all three edge functions share one sign (positive for CCW, negative for CW).
+#[inline]
+pub fn edge(ax: i32, ay: i32, bx: i32, by: i32, px: i32, py: i32) -> i32 {
+    (bx - ax) * (py - ay) - (by - ay) * (px - ax)
+}
+
+/// Is pixel `(px, py)` inside (or on the boundary of) the triangle? Integer, winding-agnostic.
+#[inline]
+pub fn triangle_inside(t: [i32; 6], px: i32, py: i32) -> bool {
+    let e0 = edge(t[0], t[1], t[2], t[3], px, py);
+    let e1 = edge(t[2], t[3], t[4], t[5], px, py);
+    let e2 = edge(t[4], t[5], t[0], t[1], px, py);
+    (e0 >= 0 && e1 >= 0 && e2 >= 0) || (e0 <= 0 && e1 <= 0 && e2 <= 0)
+}
+
+/// Deterministic integer rasterization of a triangle into cropped scanlines.
+///
+/// Scans the clamped bounding box and emits, per row, the contiguous covered run (valid
+/// triangles are convex, so inside pixels on a row are contiguous). This is the rasterizer the
+/// GPU kernel reproduces pixel-for-pixel.
+pub fn rasterize_triangle_int(t: [i32; 6], w: i32, h: i32, buf: &mut Vec<Scanline>) {
+    let xmin = clamp_i32(t[0].min(t[2]).min(t[4]), 0, w - 1);
+    let xmax = clamp_i32(t[0].max(t[2]).max(t[4]), 0, w - 1);
+    let ymin = clamp_i32(t[1].min(t[3]).min(t[5]), 0, h - 1);
+    let ymax = clamp_i32(t[1].max(t[3]).max(t[5]), 0, h - 1);
+    for py in ymin..=ymax {
+        let mut lo = -1;
+        let mut hi = -1;
+        for px in xmin..=xmax {
+            if triangle_inside(t, px, py) {
+                if lo < 0 {
+                    lo = px;
+                }
+                hi = px;
+            }
+        }
+        if lo >= 0 {
+            buf.push(Scanline {
+                y: py,
+                x1: lo,
+                x2: hi,
+                alpha: 0xffff,
+            });
+        }
+    }
+}
+
+/// Is pixel `(px, py)` inside (or on the boundary of) the axis-aligned ellipse centred `(cx, cy)`
+/// with radii `(rx, ry)`? The integer implicit test `ry²·dx² + rx²·dy² ≤ rx²·ry²` — no `sqrt`, so
+/// it's trivially identical on CPU and GPU (the integer analogue of [`triangle_inside`]). Squaring
+/// makes the sign of `rx`/`ry` irrelevant. Computed in `i64`: `ry²·dx²` overflows `i32` past ~46k px,
+/// so the GPU mirror (i32) is valid only within the documented canvas bound (§6.6), where the two
+/// agree bit-for-bit because no overflow occurs.
+#[inline]
+pub fn ellipse_inside(cx: i32, cy: i32, rx: i32, ry: i32, px: i32, py: i32) -> bool {
+    let dx = (px - cx) as i64;
+    let dy = (py - cy) as i64;
+    let (rx, ry) = (rx as i64, ry as i64);
+    ry * ry * dx * dx + rx * rx * dy * dy <= rx * rx * ry * ry
+}
+
+/// Deterministic integer rasterization of an axis-aligned ellipse into cropped scanlines. Scans the
+/// clamped bounding box and emits, per row, the contiguous covered run (ellipses are convex, so
+/// inside pixels on a row are contiguous). The integer counterpart of [`crate::raster::rasterize_ellipse`]
+/// and the rasterizer the GPU kernel will reproduce pixel-for-pixel (CORE-3b).
+pub fn rasterize_ellipse_int(
+    cx: i32,
+    cy: i32,
+    rx: i32,
+    ry: i32,
+    w: i32,
+    h: i32,
+    buf: &mut Vec<Scanline>,
+) {
+    let (rx, ry) = (rx.abs(), ry.abs());
+    let xmin = clamp_i32(cx - rx, 0, w - 1);
+    let xmax = clamp_i32(cx + rx, 0, w - 1);
+    let ymin = clamp_i32(cy - ry, 0, h - 1);
+    let ymax = clamp_i32(cy + ry, 0, h - 1);
+    for py in ymin..=ymax {
+        let mut lo = -1;
+        let mut hi = -1;
+        for px in xmin..=xmax {
+            if ellipse_inside(cx, cy, rx, ry, px, py) {
+                if lo < 0 {
+                    lo = px;
+                }
+                hi = px;
+            }
+        }
+        if lo >= 0 {
+            buf.push(Scanline {
+                y: py,
+                x1: lo,
+                x2: hi,
+                alpha: 0xffff,
+            });
+        }
+    }
+}
+
+/// Deterministic integer rasterization of an axis-aligned rectangle with inclusive opposite corners
+/// `(x1, y1)`–`(x2, y2)` (any order) into cropped scanlines: one full-width span per row, clamped to
+/// the image. Already all-integer (no f64 to diverge), so the GPU mirror is trivial; this is the
+/// self-cropping counterpart of [`crate::raster::rasterize_rectangle`] (which leaves cropping to the caller).
+pub fn rasterize_rectangle_int(
+    x1: i32,
+    y1: i32,
+    x2: i32,
+    y2: i32,
+    w: i32,
+    h: i32,
+    buf: &mut Vec<Scanline>,
+) {
+    let xlo = clamp_i32(x1.min(x2), 0, w - 1);
+    let xhi = clamp_i32(x1.max(x2), 0, w - 1);
+    let ylo = clamp_i32(y1.min(y2), 0, h - 1);
+    let yhi = clamp_i32(y1.max(y2), 0, h - 1);
+    for py in ylo..=yhi {
+        buf.push(Scanline {
+            y: py,
+            x1: xlo,
+            x2: xhi,
+            alpha: 0xffff,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raster::rasterize_ellipse;
+
+    #[test]
+    fn int_raster_coverage_is_contiguous_and_inside() {
+        let t = [2, 2, 30, 6, 10, 28];
+        let mut buf = Vec::new();
+        rasterize_triangle_int(t, 32, 32, &mut buf);
+        assert!(!buf.is_empty());
+        for s in &buf {
+            assert!(s.x1 <= s.x2);
+            // every pixel in the emitted run is actually inside
+            for x in s.x1..=s.x2 {
+                assert!(triangle_inside(t, x, s.y), "({x},{}) not inside", s.y);
+            }
+            // the pixel just left of the run is outside (run is the maximal inside span)
+            if s.x1 > 0 {
+                assert!(!triangle_inside(t, s.x1 - 1, s.y));
+            }
+        }
+    }
+
+    #[test]
+    fn int_raster_is_deterministic() {
+        let t = [1, 0, 20, 5, 7, 19];
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        rasterize_triangle_int(t, 24, 24, &mut a);
+        rasterize_triangle_int(t, 24, 24, &mut b);
+        assert_eq!(a, b);
+    }
+
+    // ── CORE-3b.1: integer ellipse / rectangle rasterizers (the GPU-shared path) ──────────
+
+    #[test]
+    fn ellipse_inside_matches_implicit_test() {
+        // centre + the four axis extrema are on/inside the boundary; one step past each axis is out.
+        let (cx, cy, rx, ry) = (10, 10, 6, 3);
+        assert!(ellipse_inside(cx, cy, rx, ry, cx, cy), "centre is inside");
+        assert!(
+            ellipse_inside(cx, cy, rx, ry, cx + rx, cy),
+            "+x vertex on boundary"
+        );
+        assert!(
+            ellipse_inside(cx, cy, rx, ry, cx - rx, cy),
+            "-x vertex on boundary"
+        );
+        assert!(
+            ellipse_inside(cx, cy, rx, ry, cx, cy + ry),
+            "+y vertex on boundary"
+        );
+        assert!(
+            ellipse_inside(cx, cy, rx, ry, cx, cy - ry),
+            "-y vertex on boundary"
+        );
+        assert!(
+            !ellipse_inside(cx, cy, rx, ry, cx + rx + 1, cy),
+            "one past +x is outside"
+        );
+        assert!(
+            !ellipse_inside(cx, cy, rx, ry, cx, cy + ry + 1),
+            "one past +y is outside"
+        );
+        assert!(
+            !ellipse_inside(cx, cy, rx, ry, cx + rx, cy + ry),
+            "the bbox corner is outside"
+        );
+    }
+
+    #[test]
+    fn int_ellipse_raster_is_contiguous_inside_and_symmetric() {
+        let (cx, cy, rx, ry) = (16, 16, 10, 6);
+        let mut buf = Vec::new();
+        rasterize_ellipse_int(cx, cy, rx, ry, 40, 40, &mut buf);
+        assert!(!buf.is_empty());
+        for s in &buf {
+            assert!(s.x1 <= s.x2);
+            // every emitted pixel is inside, and the run is maximal (pixel left of it is outside).
+            for x in s.x1..=s.x2 {
+                assert!(
+                    ellipse_inside(cx, cy, rx, ry, x, s.y),
+                    "({x},{}) not inside",
+                    s.y
+                );
+            }
+            if s.x1 > 0 {
+                assert!(!ellipse_inside(cx, cy, rx, ry, s.x1 - 1, s.y));
+            }
+            // each row's covered span is symmetric about the centre column.
+            assert_eq!(s.x1 + s.x2, 2 * cx, "row {} span not centred on cx", s.y);
+        }
+        // vertical symmetry: row cy-k and cy+k cover identical spans.
+        let span = |y: i32| buf.iter().find(|s| s.y == y).map(|s| (s.x1, s.x2));
+        for k in 1..=ry {
+            assert_eq!(
+                span(cy - k),
+                span(cy + k),
+                "rows {} / {} differ",
+                cy - k,
+                cy + k
+            );
+        }
+    }
+
+    #[test]
+    fn int_ellipse_raster_is_deterministic() {
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        rasterize_ellipse_int(12, 9, 7, 5, 30, 30, &mut a);
+        rasterize_ellipse_int(12, 9, 7, 5, 30, 30, &mut b);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn int_rect_raster_clamps_and_spans_corner_order_invariant() {
+        // a rect fully inside the image: one full-width span per row, inclusive corners.
+        let mut buf = Vec::new();
+        rasterize_rectangle_int(4, 5, 9, 8, 20, 20, &mut buf);
+        assert_eq!(buf.len(), 4, "rows 5..=8");
+        for (i, s) in buf.iter().enumerate() {
+            assert_eq!((s.y, s.x1, s.x2, s.alpha), (5 + i as i32, 4, 9, 0xffff));
+        }
+        // corner order doesn't matter (min/max normalised).
+        let mut swapped = Vec::new();
+        rasterize_rectangle_int(9, 8, 4, 5, 20, 20, &mut swapped);
+        assert_eq!(buf, swapped);
+        // a rect straddling the edges is cropped to the image, never out of bounds.
+        let mut clipped = Vec::new();
+        rasterize_rectangle_int(-3, -2, 5, 100, 10, 10, &mut clipped);
+        assert_eq!(clipped.len(), 10, "rows 0..=9 (y2 clamped to h-1)");
+        for s in &clipped {
+            assert_eq!((s.x1, s.x2), (0, 5), "x clamped to [0, 5]");
+            assert!(s.y >= 0 && s.y < 10);
+        }
+    }
+
+    #[test]
+    fn int_ellipse_roughly_matches_f64_reference() {
+        // the integer implicit test and fogleman's f64 scanline raster cover nearly the same pixels
+        // (sub-pixel edges differ, as for triangles); assert the covered-pixel counts agree to ≤ 8%.
+        let (cx, cy, rx, ry) = (24, 24, 14, 9);
+        let mut iref = Vec::new();
+        rasterize_ellipse(cx, cy, rx, ry, 50, 50, &mut iref);
+        let mut iint = Vec::new();
+        rasterize_ellipse_int(cx, cy, rx, ry, 50, 50, &mut iint);
+        let area = |b: &[Scanline]| b.iter().map(|s| (s.x2 - s.x1 + 1) as i64).sum::<i64>();
+        let (fa, ia) = (area(&iref), area(&iint));
+        let diff = (fa - ia).abs() as f64 / fa as f64;
+        assert!(
+            diff <= 0.08,
+            "int ellipse area {ia} vs f64 {fa} differ {:.1}%",
+            diff * 100.0
+        );
+    }
+}

--- a/crates/primitive-gpu-cubecl/src/kernels.rs
+++ b/crates/primitive-gpu-cubecl/src/kernels.rs
@@ -68,7 +68,7 @@ pub(crate) fn clampi(x: i32, lo: i32, hi: i32) -> i32 {
     r
 }
 
-/// Integer edge-function inside test — mirrors `primitive_core::raster::triangle_inside`.
+/// Integer edge-function inside test — mirrors `primitive_core::raster_int::triangle_inside`.
 #[cube]
 fn inside(t0: i32, t1: i32, t2: i32, t3: i32, t4: i32, t5: i32, px: i32, py: i32) -> bool {
     let e0 = (t2 - t0) * (py - t1) - (t3 - t1) * (px - t0);


### PR DESCRIPTION
## Summary

The foundation for the GPU shape-set expansion (CORE-3b). The GPU kernel and its CPU oracle must cover the **exact same pixels**, but Metal has no f64 — so ellipse/rect need **integer** rasterizers, mirroring the existing triangle path (`rasterize_triangle_int` / `triangle_inside`).

## What's in

- **`ellipse_inside(cx,cy,rx,ry,px,py)`** — the integer implicit test `ry²·dx² + rx²·dy² ≤ rx²·ry²` (no `sqrt`; the integer analogue of `triangle_inside`). Computed in `i64`: `ry²·dx²` overflows `i32` past ~46k px, so the GPU mirror (i32) is valid within the documented **≤128-px canvas bound** (§6.6), where the two agree bit-for-bit (no overflow).
- **`rasterize_ellipse_int`** — bbox-scan emitting the per-row contiguous run (ellipses are convex), the integer counterpart of fogleman's f64 `rasterize_ellipse`.
- **`rasterize_rectangle_int`** — self-cropping integer bbox (already all-integer; trivial GPU mirror).

## Refactor (size gate, not allowlist)

The additions pushed `raster.rs` to 516 LOC (> 500 hard gate), so the integer rasterizers split into a new **`raster_int.rs`** module — the seam the file's own comment already drew: **f64 golden reference in `raster.rs` ←→ integer GPU-shared path in `raster_int.rs`**. `clamp_i32` is `pub(crate)`-shared. Both files now ~220–300 LOC.

## Gate (green in `make verify`; `raster_int.rs` tests, 7 total)

- `ellipse_inside_matches_implicit_test` — centre + 4 axis extrema inside/on-boundary; one step past each axis + the bbox corner outside.
- `int_ellipse_raster_is_contiguous_inside_and_symmetric` — every emitted pixel inside, maximal run, each row's span centred on `cx` (`x1+x2 == 2·cx`), vertical symmetry.
- `int_ellipse_roughly_matches_f64_reference` — integer raster covers within **8%** of fogleman's f64 scanline area.
- `int_rect_raster_clamps_and_spans_corner_order_invariant` — full-width span/row, corner-order invariant, cropped to image.
- determinism (byte-identical) for ellipse + carried-over triangle int tests.

## Follow-up

Not yet GPU-wired. **CORE-3b.2** generalizes the score kernel to consume these on-device with GPU↔CPU bit-identical parity (like GPU-2 for triangles); **CORE-3b.3** the `evolve`/`commit` search loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)