### PR TITLE
feat(gpu): CORE-3 Part B.2 — on-device score kernels for ellipse + rectangle

### DIFF
--- a/.agent/EVIDENCE.md
+++ b/.agent/EVIDENCE.md
@@ -268,7 +268,11 @@ make verify ...................................................... verify: ALL G
 ```
 The `score_ellipses`/`score_rectangles` kernels (new `score_shapes.rs`: in-kernel integer raster via
 `inside_ellipse` / the rect bbox + the proven `score_one` color+delta math) reproduce
-`rasterize_ellipse_int`/`rasterize_rectangle_int` + `candidate_color_and_delta` exactly for 1000 random
-candidates each. Host: `EllipseBatch`/`RectBatch` + `GpuSession::score_ellipses`/`score_rects` +
-one-shot `gpu_score_ellipses`/`gpu_score_rectangles`; `Shape::ellipse_coords`/`rectangle_coords`
-accessors. Scorer only — the GPU search loop (`evolve`/`commit`) is CORE-3b.3.
+`rasterize_ellipse_int`/`rasterize_rectangle_int` + `candidate_color_and_delta` exactly for 1000
+candidates each (each **mutated 4×** so the gate covers the larger-radii / near-edge domain the 3b.3
+search will feed, not just freshly-rolled shapes). Host: `EllipseBatch`/`RectBatch` +
+`GpuSession::score_ellipses`/`score_rects` + one-shot `gpu_score_ellipses`/`gpu_score_rectangles`;
+`Shape::ellipse_coords`/`rectangle_coords` accessors. Review hardening (true-mirror, not
+correct-by-precondition): the kernels now `.abs()` radii + drop fully-off-canvas rects like their CPU
+oracles, and `score_ellipses` `debug_assert`s the ≤182-px i32-safe canvas bound at dispatch. Scorer
+only — the GPU search loop (`evolve`/`commit`) is CORE-3b.3.

--- a/.agent/EVIDENCE.md
+++ b/.agent/EVIDENCE.md
@@ -257,3 +257,18 @@ guarding the domain). `rasterize_ellipse_int` bbox-scans the per-row contiguous 
 crop, rather than saturating into a phantom column). **Refactor:** the additions took `raster.rs` to 516
 LOC (> 500 gate), so the integer rasterizers split into `raster_int.rs` (f64 golden reference stays in
 `raster.rs`); `clamp_i32` is `pub(crate)`-shared. Not yet GPU-wired — CORE-3b.2 consumes these on-device.
+
+## CORE-3 Part B.2 — on-device ellipse/rect score kernels (2026-06-29)
+
+### GPU score parity for ellipse + rect — `crates/primitive-gpu-cubecl/tests/`
+```
+gpu2_ellipses.rs::gpu2_ellipse_raster_score_matches_cpu_exactly ... ok  (1000/1000 bit-identical to CPU)
+gpu2_rects.rs::gpu2_rect_raster_score_matches_cpu_exactly ......... ok  (1000/1000 bit-identical to CPU)
+make verify ...................................................... verify: ALL GREEN (on Metal)
+```
+The `score_ellipses`/`score_rectangles` kernels (new `score_shapes.rs`: in-kernel integer raster via
+`inside_ellipse` / the rect bbox + the proven `score_one` color+delta math) reproduce
+`rasterize_ellipse_int`/`rasterize_rectangle_int` + `candidate_color_and_delta` exactly for 1000 random
+candidates each. Host: `EllipseBatch`/`RectBatch` + `GpuSession::score_ellipses`/`score_rects` +
+one-shot `gpu_score_ellipses`/`gpu_score_rectangles`; `Shape::ellipse_coords`/`rectangle_coords`
+accessors. Scorer only — the GPU search loop (`evolve`/`commit`) is CORE-3b.3.

--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -218,12 +218,11 @@ Gate evidence (all green in `make verify`; `crates/primitive-core/tests/shapes.r
   flat-background baseline** (PSNR 32.15 / 33.07 dB); SVG export emits valid `<ellipse>` / `<rect>`.
 
 Scope notes (carry-forward, by design):
-- **CORE-3b (GPU)**: staged in three. **3b.1 (integer rasterizers) ✅ DONE** — see the Part B.1
-  section below. **3b.2/3b.3 remain**: the GPU batch path is still triangle-specific (`TriangleBatch`,
-  `score_triangles`, `evolve`/`commit` all assume 6-int triangles); `Shape::triangle_coords()`
-  **panics** for non-triangles with a CORE-3b pointer. 3b.2 = generalize the score kernel to consume
-  `rasterize_ellipse_int`/`rasterize_rectangle_int` with GPU↔CPU parity; 3b.3 = generalize
-  `evolve`/`commit` (in-kernel random/mutate per shape type).
+- **CORE-3b (GPU)**: staged in three. **3b.1 (integer rasterizers) + 3b.2 (on-device score kernels)
+  ✅ DONE** — see Part B.1 / B.2 below. **3b.3 remains**: the GPU *search loop* (`evolve`/`commit`) is
+  still triangle-specific (in-kernel random/mutate over 6-int triangles), so GPU instant mode in the app
+  stays triangle-only (`runner::should_use_gpu`). 3b.3 = generalize `evolve`/`commit` (in-kernel
+  random/mutate + the scanline scorer per shape type) so ellipse/rect get the full on-device search.
 - **CORE-3c (GUI)**: ✅ DONE — see the Part C section below.
 - **CORE-3a.2 (rigour)**: fogleman **bit-exact** parity for ellipse/rect needs the Go dumper
   (`go_primitive/primitive/parity_dump_test.go`, schema is triangle-only) extended; until then the
@@ -295,3 +294,32 @@ on-device with GPU↔CPU bit-identical parity (like GPU-2 for triangles), then 3
 search loop. Minor debt (review NIT, deferred to avoid a rename-only change): `shape.rs` has a private
 `clamp_i32` byte-identical to `raster.rs`'s now-`pub(crate)` one — fold the duplicate into the next
 `shape.rs` touch.
+
+## CORE-3 Part B.2 — on-device score kernels for ellipse + rectangle — ✅ DONE (2026-06-29)
+
+The GPU can now **rasterize + score ellipse & rectangle candidates on-device**, bit-exact against the
+CPU oracle — the GPU-2 triangle path generalized to the new shapes. New module
+`crates/primitive-gpu-cubecl/src/score_shapes.rs` (keeps `kernels.rs` under the 500-LOC gate):
+
+- **`inside_ellipse`** (`#[cube]`) mirrors `raster_int::ellipse_inside` in i32 (overflow-free ≤128 px).
+- **`score_one_ellipse`** / **`score_one_rect`** mirror `kernels::score_one` (closed-form color +
+  16-bit premultiplied composite + integer delta-SSE) with the ellipse bbox + `inside_ellipse` / the
+  rect bbox (every bbox pixel inside, no per-pixel test). Reuse the proven `channel_delta`/`clamp_0_255`
+  helpers, so the parity that holds for triangles carries by construction.
+- **`score_ellipses`** / **`score_rectangles`** batch kernels (4 ints/candidate), one thread each.
+- Host: `EllipseBatch`/`RectBatch` + `GpuSession::score_ellipses`/`score_rects` + one-shot
+  `gpu_score_ellipses`/`gpu_score_rectangles`. New `Shape::ellipse_coords()`/`rectangle_coords()`
+  accessors (the `[cx,cy,rx,ry]`/`[x1,y1,x2,y2]` flat layouts the kernels consume).
+
+Gate evidence (green in `make verify`, on Metal):
+- **`gpu2_ellipses.rs`** — `score_ellipses` == `rasterize_ellipse_int` + `candidate_color_and_delta`,
+  **1000/1000 candidates bit-identical** to the CPU integer path.
+- **`gpu2_rects.rs`** — `score_rectangles` == `rasterize_rectangle_int` + `candidate_color_and_delta`,
+  **1000/1000 candidates bit-identical**.
+
+Cleanup folded in (3b.1 review NIT): `shape.rs`'s private `clamp_i32` removed — now uses the shared
+`raster::clamp_i32` (`pub(crate)`).
+
+Carry-forward: this is the **scorer** only. CORE-3b.3 generalizes the GPU *search loop*
+(`search::evolve`/`commit` — in-kernel random/mutate per shape type) so the app's GPU instant mode can
+drop the triangle-only guard and run ellipse/rect fully on-device.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,12 +44,13 @@ core (pure) ← compute (ports) ← engine (orchestration) ← adapters / app (c
 - **CORE-2 parity + CPU baseline** — `crates/primitive-engine/tests/cpu_baseline.rs` (byte-identical to core; prints shapes/sec).
 - **GPU-1/2/3** — integer-SSE parity + on-device search in `crates/primitive-gpu-cubecl/tests/*` (Metal; `make verify` runs them). The **throughput** thresholds (GPU-2 ≥20×, GPU-3 ≥460 sps) are hardware-dependent → enforced by `make perf`, not `make verify` (see `tests/common/mod.rs`); the PSNR + integer-parity gates stay in `make verify`.
 - **CORE-3 Part A** (Ellipse + Rectangle, core + CPU) — `crates/primitive-core/tests/shapes.rs` (rasterizer geometry, determinism, effectiveness). `Shape::triangle_coords()` panics for non-triangles until the GPU kernels generalize (CORE-3b).
-- **CORE-3 Part B.1** (integer ellipse/rect rasterizers, the GPU-shared §6.6 path) — `crates/primitive-core/src/raster_int.rs` (new module; f64 golden reference stays in `raster.rs`). `ellipse_inside` = integer implicit test `ry²·dx²+rx²·dy² ≤ rx²·ry²`; `rasterize_ellipse_int`/`rasterize_rectangle_int`. Not yet GPU-wired (CORE-3b.2).
+- **CORE-3 Part B.1** (integer ellipse/rect rasterizers, the GPU-shared §6.6 path) — `crates/primitive-core/src/raster_int.rs` (new module; f64 golden reference stays in `raster.rs`). `ellipse_inside` = integer implicit test `ry²·dx²+rx²·dy² ≤ rx²·ry²`; `rasterize_ellipse_int`/`rasterize_rectangle_int`.
+- **CORE-3 Part B.2** (on-device ellipse/rect score kernels) — `crates/primitive-gpu-cubecl/src/score_shapes.rs` (`score_ellipses`/`score_rectangles`), tests `gpu2_ellipses.rs`/`gpu2_rects.rs` (1000/1000 bit-identical to the CPU integer path on Metal). The GPU *search loop* (`evolve`/`commit`) stays triangle-only until CORE-3b.3, so app GPU instant mode is still triangle-only.
 - **CORE-3 Part C** (GUI shape selector) — `crates/primitive-app/tests/e2e.rs` (ellipse run → `<ellipse>` SVG), `runner::tests` (pure `should_use_gpu` routing guard), `a11y_tree.rs` (all three options in the AccessKit tree + click mutates selection). `ShapeType` is selectable + persisted; GPU instant mode stays triangle-only (CORE-3b).
 - **GUI-2** — the §5A interaction gates in `crates/primitive-app/tests/*` (`state_suite` pure-state matrix,
   `e2e` load→100→SVG, `forced_cpu` device chip, `a11y_tree` AccessKit, `a11y_tokens` WCAG/Reduce-Motion).
 
-Full milestone state (CORE-1/2 · GPU-1/2/3 · GUI-1/2 · PKG-1 Part A · CORE-3 Part A+B.1+C — all ✅) lives in `.agent/PROGRESS.md` + `.agent/EVIDENCE.md`.
+Full milestone state (CORE-1/2 · GPU-1/2/3 · GUI-1/2 · PKG-1 Part A · CORE-3 Part A+B.1+B.2+C — all ✅) lives in `.agent/PROGRESS.md` + `.agent/EVIDENCE.md`.
 
 ## Rules for changes here
 

--- a/crates/primitive-core/src/shape.rs
+++ b/crates/primitive-core/src/shape.rs
@@ -6,7 +6,7 @@
 //! closed-form (`color.rs`), never mutated here.
 
 use crate::raster::{
-    crop_scanlines, rasterize_ellipse, rasterize_rectangle, rasterize_triangle, Scanline,
+    clamp_i32, crop_scanlines, rasterize_ellipse, rasterize_rectangle, rasterize_triangle, Scanline,
 };
 use crate::rng::Rng;
 
@@ -68,28 +68,30 @@ impl Shape {
     }
 
     /// Flat `[x1, y1, x2, y2, x3, y3]` — the layout the GPU `score_triangles` kernel consumes.
-    /// Triangle-only: the GPU batch path is triangle-specific until CORE-3b generalizes the kernels.
     pub fn triangle_coords(&self) -> [i32; 6] {
         match self {
             Shape::Triangle(t) => [t.x1, t.y1, t.x2, t.y2, t.x3, t.y3],
             Shape::Ellipse(_) | Shape::Rectangle(_) => {
-                panic!("triangle_coords called on a non-triangle shape; the GPU batch path is triangle-only until CORE-3b")
+                panic!("triangle_coords called on a non-triangle shape (use ellipse_coords / rectangle_coords)")
             }
         }
     }
-}
 
-/// Clamp to `[lo, hi]` with fogleman's `clampInt` semantics: the lower bound wins when `lo > hi`
-/// (Go checks `x < lo` first). Identical to `max(lo).min(hi)` whenever `lo <= hi` (the only case the
-/// Triangle clamps hit); the `lo > hi` branch matters only for radii clamps on a 1-px-dim canvas.
-#[inline]
-fn clamp_i32(x: i32, lo: i32, hi: i32) -> i32 {
-    if x < lo {
-        lo
-    } else if x > hi {
-        hi
-    } else {
-        x
+    /// Flat `[cx, cy, rx, ry]` — the layout the GPU `score_ellipses` kernel consumes (CORE-3b.2).
+    pub fn ellipse_coords(&self) -> [i32; 4] {
+        match self {
+            Shape::Ellipse(e) => [e.x, e.y, e.rx, e.ry],
+            _ => panic!("ellipse_coords called on a non-ellipse shape"),
+        }
+    }
+
+    /// Flat `[x1, y1, x2, y2]` (opposite corners) — the layout the GPU `score_rectangles` kernel
+    /// consumes (CORE-3b.2).
+    pub fn rectangle_coords(&self) -> [i32; 4] {
+        match self {
+            Shape::Rectangle(r) => [r.x1, r.y1, r.x2, r.y2],
+            _ => panic!("rectangle_coords called on a non-rectangle shape"),
+        }
     }
 }
 

--- a/crates/primitive-gpu-cubecl/src/lib.rs
+++ b/crates/primitive-gpu-cubecl/src/lib.rs
@@ -182,6 +182,15 @@ impl GpuSession {
     /// Rasterize + score every **ellipse** candidate on the GPU (CORE-3b.2); integer delta-SSE per
     /// candidate, exact vs `rasterize_ellipse_int` + `candidate_color_and_delta` on the CPU.
     pub fn score_ellipses(&self, b: &EllipseBatch) -> Vec<i32> {
+        // The in-kernel `inside_ellipse` test is i32 (Metal has no i64). Its degree-4 product
+        // `ry²·dx²` overflows once an operand exceeds ~181 (radii ≤ w-1 ≤ h-1), so the GPU agrees with
+        // the i64 CPU oracle only within this canvas bound (§6.6). The app caps at 128 (GPU_INSTANT_MAX).
+        debug_assert!(
+            self.w <= 182 && self.h <= 182,
+            "score_ellipses: {}×{} canvas exceeds the i32-safe bound (radii could overflow the i32 GPU ellipse test; §6.6)",
+            self.w,
+            self.h
+        );
         let n = b.alphas.len();
         let ells_h = self.client.create_from_slice(bytemuck::cast_slice(&b.ells));
         let alpha_h = self

--- a/crates/primitive-gpu-cubecl/src/lib.rs
+++ b/crates/primitive-gpu-cubecl/src/lib.rs
@@ -17,6 +17,7 @@
 //! is GPU-2 hardening tracked in `.agent/PROGRESS.md`.
 
 mod kernels;
+mod score_shapes;
 mod search;
 
 use cubecl::prelude::*;
@@ -75,6 +76,22 @@ pub fn gpu_score_candidates(target: &Canvas, current: &Canvas, c: &CandidateSpan
 pub struct TriangleBatch {
     /// 6 ints per candidate: `[x1, y1, x2, y2, x3, y3]`.
     pub tris: Vec<i32>,
+    /// Per-candidate fill alpha.
+    pub alphas: Vec<i32>,
+}
+
+/// A batch of ellipse candidates for the on-device scorer (CORE-3b.2).
+pub struct EllipseBatch {
+    /// 4 ints per candidate: `[cx, cy, rx, ry]`.
+    pub ells: Vec<i32>,
+    /// Per-candidate fill alpha.
+    pub alphas: Vec<i32>,
+}
+
+/// A batch of axis-aligned rectangle candidates for the on-device scorer (CORE-3b.2).
+pub struct RectBatch {
+    /// 4 ints per candidate: `[x1, y1, x2, y2]` (opposite corners).
+    pub rects: Vec<i32>,
     /// Per-candidate fill alpha.
     pub alphas: Vec<i32>,
 }
@@ -161,6 +178,60 @@ impl GpuSession {
         let idx: Vec<i32> = bytemuck::cast_slice(&self.client.read_one_unchecked(idx_h)).to_vec();
         idx[0]
     }
+
+    /// Rasterize + score every **ellipse** candidate on the GPU (CORE-3b.2); integer delta-SSE per
+    /// candidate, exact vs `rasterize_ellipse_int` + `candidate_color_and_delta` on the CPU.
+    pub fn score_ellipses(&self, b: &EllipseBatch) -> Vec<i32> {
+        let n = b.alphas.len();
+        let ells_h = self.client.create_from_slice(bytemuck::cast_slice(&b.ells));
+        let alpha_h = self
+            .client
+            .create_from_slice(bytemuck::cast_slice(&b.alphas));
+        let out_h = self.client.empty(n * core::mem::size_of::<i32>());
+        unsafe {
+            score_shapes::score_ellipses::launch_unchecked::<WgpuRuntime>(
+                &self.client,
+                CubeCount::Static((n as u32).div_ceil(THREADS), 1, 1),
+                CubeDim::new_1d(THREADS),
+                ArrayArg::from_raw_parts(self.target_h.clone(), self.tlen),
+                ArrayArg::from_raw_parts(self.current_h.clone(), self.clen),
+                ArrayArg::from_raw_parts(ells_h.clone(), b.ells.len()),
+                ArrayArg::from_raw_parts(alpha_h.clone(), n),
+                self.w,
+                self.h,
+                ArrayArg::from_raw_parts(out_h.clone(), n),
+            );
+        }
+        bytemuck::cast_slice(&self.client.read_one_unchecked(out_h)).to_vec()
+    }
+
+    /// Rasterize + score every **rectangle** candidate on the GPU (CORE-3b.2); exact vs
+    /// `rasterize_rectangle_int` + `candidate_color_and_delta` on the CPU.
+    pub fn score_rects(&self, b: &RectBatch) -> Vec<i32> {
+        let n = b.alphas.len();
+        let rects_h = self
+            .client
+            .create_from_slice(bytemuck::cast_slice(&b.rects));
+        let alpha_h = self
+            .client
+            .create_from_slice(bytemuck::cast_slice(&b.alphas));
+        let out_h = self.client.empty(n * core::mem::size_of::<i32>());
+        unsafe {
+            score_shapes::score_rectangles::launch_unchecked::<WgpuRuntime>(
+                &self.client,
+                CubeCount::Static((n as u32).div_ceil(THREADS), 1, 1),
+                CubeDim::new_1d(THREADS),
+                ArrayArg::from_raw_parts(self.target_h.clone(), self.tlen),
+                ArrayArg::from_raw_parts(self.current_h.clone(), self.clen),
+                ArrayArg::from_raw_parts(rects_h.clone(), b.rects.len()),
+                ArrayArg::from_raw_parts(alpha_h.clone(), n),
+                self.w,
+                self.h,
+                ArrayArg::from_raw_parts(out_h.clone(), n),
+            );
+        }
+        bytemuck::cast_slice(&self.client.read_one_unchecked(out_h)).to_vec()
+    }
 }
 
 /// GPU-2 one-shot: rasterize + score a batch (uploads target/current per call). For repeated
@@ -172,6 +243,16 @@ pub fn gpu_score_triangles(target: &Canvas, current: &Canvas, b: &TriangleBatch)
 /// GPU-2 one-shot: the winning candidate index via the on-device argmin.
 pub fn gpu_best_triangle(target: &Canvas, current: &Canvas, b: &TriangleBatch) -> i32 {
     GpuSession::new(target, current).best_triangle(b)
+}
+
+/// CORE-3b.2 one-shot: rasterize + score an ellipse batch (uploads target/current per call).
+pub fn gpu_score_ellipses(target: &Canvas, current: &Canvas, b: &EllipseBatch) -> Vec<i32> {
+    GpuSession::new(target, current).score_ellipses(b)
+}
+
+/// CORE-3b.2 one-shot: rasterize + score a rectangle batch (uploads target/current per call).
+pub fn gpu_score_rectangles(target: &Canvas, current: &Canvas, b: &RectBatch) -> Vec<i32> {
+    GpuSession::new(target, current).score_rects(b)
 }
 
 /// GPU-3 search configuration. Per shape, `workers` independent hill-climbs each run `age`

--- a/crates/primitive-gpu-cubecl/src/score_shapes.rs
+++ b/crates/primitive-gpu-cubecl/src/score_shapes.rs
@@ -36,10 +36,15 @@ pub fn score_one_ellipse(
     height: i32,
 ) -> i32 {
     let a_coef = 65535 / alpha;
-    let xmin = clampi(cx - rx, 0, width - 1);
-    let xmax = clampi(cx + rx, 0, width - 1);
-    let ymin = clampi(cy - ry, 0, height - 1);
-    let ymax = clampi(cy + ry, 0, height - 1);
+    // Mirror the CPU `rasterize_ellipse_int`'s `(rx.abs(), ry.abs())` so a negative radius can't
+    // invert the bbox into an empty loop (unreachable today — radii clamp ≥ 1 — but keeps the kernel
+    // a true mirror of its oracle rather than correct only by precondition).
+    let arx = if rx < 0 { -rx } else { rx };
+    let ary = if ry < 0 { -ry } else { ry };
+    let xmin = clampi(cx - arx, 0, width - 1);
+    let xmax = clampi(cx + arx, 0, width - 1);
+    let ymin = clampi(cy - ary, 0, height - 1);
+    let ymax = clampi(cy + ary, 0, height - 1);
 
     let mut rsum = 0i32;
     let mut gsum = 0i32;
@@ -47,7 +52,7 @@ pub fn score_one_ellipse(
     let mut count = 0i32;
     for py in ymin..ymax + 1 {
         for px in xmin..xmax + 1 {
-            if inside_ellipse(cx, cy, rx, ry, px, py) {
+            if inside_ellipse(cx, cy, arx, ary, px, py) {
                 let idx = ((py * width + px) * 4) as usize;
                 rsum += (target[idx] - current[idx]) * a_coef + current[idx] * 257;
                 gsum += (target[idx + 1] - current[idx + 1]) * a_coef + current[idx + 1] * 257;
@@ -70,7 +75,7 @@ pub fn score_one_ellipse(
         let aa = (65535 - sa * 65535 / 65535) * 257;
         for py in ymin..ymax + 1 {
             for px in xmin..xmax + 1 {
-                if inside_ellipse(cx, cy, rx, ry, px, py) {
+                if inside_ellipse(cx, cy, arx, ary, px, py) {
                     let idx = ((py * width + px) * 4) as usize;
                     delta += channel_delta(target[idx], current[idx], sr, aa);
                     delta += channel_delta(target[idx + 1], current[idx + 1], sg, aa);
@@ -104,6 +109,10 @@ pub fn score_one_rect(
     let xb = if x1 < x2 { x2 } else { x1 };
     let ya = if y1 < y2 { y1 } else { y2 };
     let yb = if y1 < y2 { y2 } else { y1 };
+    // Mirror the CPU `rasterize_rectangle_int`'s off-canvas drop: a fully-off-canvas rect scores 0
+    // (count stays 0) rather than saturating clampi into a phantom 1-px edge column. Unreachable
+    // today (corners clamp in-bounds) but keeps the kernel a true mirror of its oracle.
+    let in_bounds = xb >= 0 && xa < width && yb >= 0 && ya < height;
     let xmin = clampi(xa, 0, width - 1);
     let xmax = clampi(xb, 0, width - 1);
     let ymin = clampi(ya, 0, height - 1);
@@ -113,13 +122,15 @@ pub fn score_one_rect(
     let mut gsum = 0i32;
     let mut bsum = 0i32;
     let mut count = 0i32;
-    for py in ymin..ymax + 1 {
-        for px in xmin..xmax + 1 {
-            let idx = ((py * width + px) * 4) as usize;
-            rsum += (target[idx] - current[idx]) * a_coef + current[idx] * 257;
-            gsum += (target[idx + 1] - current[idx + 1]) * a_coef + current[idx + 1] * 257;
-            bsum += (target[idx + 2] - current[idx + 2]) * a_coef + current[idx + 2] * 257;
-            count += 1;
+    if in_bounds {
+        for py in ymin..ymax + 1 {
+            for px in xmin..xmax + 1 {
+                let idx = ((py * width + px) * 4) as usize;
+                rsum += (target[idx] - current[idx]) * a_coef + current[idx] * 257;
+                gsum += (target[idx + 1] - current[idx + 1]) * a_coef + current[idx + 1] * 257;
+                bsum += (target[idx + 2] - current[idx + 2]) * a_coef + current[idx + 2] * 257;
+                count += 1;
+            }
         }
     }
 

--- a/crates/primitive-gpu-cubecl/src/score_shapes.rs
+++ b/crates/primitive-gpu-cubecl/src/score_shapes.rs
@@ -1,0 +1,206 @@
+//! CORE-3b.2 — on-device score kernels for **ellipse** & **rectangle** candidates.
+//!
+//! Mirror the triangle path in [`crate::kernels`] (`score_one` / `score_triangles`): in-kernel
+//! integer raster + closed-form color + integer delta-SSE, held to **exact** parity against the CPU
+//! oracle (`primitive_core::rasterize_ellipse_int` / `rasterize_rectangle_int` +
+//! `candidate_color_and_delta`). Only the bounding box + inside test differ per shape; the
+//! color/delta block is the same proven arithmetic as `score_one`, so the parity that holds for
+//! triangles carries to these by construction.
+
+use cubecl::prelude::*;
+
+use crate::kernels::{channel_delta, clamp_0_255, clampi};
+
+/// Integer point-in-ellipse test — mirrors `primitive_core::raster_int::ellipse_inside`
+/// (`ry²·dx² + rx²·dy² ≤ rx²·ry²`, no `sqrt`). i32; overflow-free within the ≤128-px canvas bound
+/// (the degree-4 product peaks at `2·128⁴ ≈ 5.4e8`, ~4× under i32::MAX — §6.6).
+#[cube]
+fn inside_ellipse(cx: i32, cy: i32, rx: i32, ry: i32, px: i32, py: i32) -> bool {
+    let dx = px - cx;
+    let dy = py - cy;
+    ry * ry * dx * dx + rx * rx * dy * dy <= rx * rx * ry * ry
+}
+
+/// Integer delta-SSE of compositing one ellipse (centre `cx,cy`, radii `rx,ry`, fill `alpha`) over
+/// `current` toward `target`. Mirrors `score_one` with the ellipse bbox + `inside_ellipse`.
+#[cube]
+pub fn score_one_ellipse(
+    target: &Array<i32>,
+    current: &Array<i32>,
+    cx: i32,
+    cy: i32,
+    rx: i32,
+    ry: i32,
+    alpha: i32,
+    width: i32,
+    height: i32,
+) -> i32 {
+    let a_coef = 65535 / alpha;
+    let xmin = clampi(cx - rx, 0, width - 1);
+    let xmax = clampi(cx + rx, 0, width - 1);
+    let ymin = clampi(cy - ry, 0, height - 1);
+    let ymax = clampi(cy + ry, 0, height - 1);
+
+    let mut rsum = 0i32;
+    let mut gsum = 0i32;
+    let mut bsum = 0i32;
+    let mut count = 0i32;
+    for py in ymin..ymax + 1 {
+        for px in xmin..xmax + 1 {
+            if inside_ellipse(cx, cy, rx, ry, px, py) {
+                let idx = ((py * width + px) * 4) as usize;
+                rsum += (target[idx] - current[idx]) * a_coef + current[idx] * 257;
+                gsum += (target[idx + 1] - current[idx + 1]) * a_coef + current[idx + 1] * 257;
+                bsum += (target[idx + 2] - current[idx + 2]) * a_coef + current[idx + 2] * 257;
+                count += 1;
+            }
+        }
+    }
+
+    let mut delta = 0i32;
+    if count > 0 {
+        let r = clamp_0_255((rsum / count) >> 8);
+        let g = clamp_0_255((gsum / count) >> 8);
+        let b = clamp_0_255((bsum / count) >> 8);
+        let av = alpha as u32;
+        let sr = ((r as u32) | ((r as u32) << 8)) * av / 255;
+        let sg = ((g as u32) | ((g as u32) << 8)) * av / 255;
+        let sb = ((b as u32) | ((b as u32) << 8)) * av / 255;
+        let sa = av | (av << 8);
+        let aa = (65535 - sa * 65535 / 65535) * 257;
+        for py in ymin..ymax + 1 {
+            for px in xmin..xmax + 1 {
+                if inside_ellipse(cx, cy, rx, ry, px, py) {
+                    let idx = ((py * width + px) * 4) as usize;
+                    delta += channel_delta(target[idx], current[idx], sr, aa);
+                    delta += channel_delta(target[idx + 1], current[idx + 1], sg, aa);
+                    delta += channel_delta(target[idx + 2], current[idx + 2], sb, aa);
+                    delta += channel_delta(target[idx + 3], current[idx + 3], sa, aa);
+                }
+            }
+        }
+    }
+    delta
+}
+
+/// Integer delta-SSE of compositing one axis-aligned rectangle (opposite corners `(x1,y1)`–`(x2,y2)`,
+/// fill `alpha`). Mirrors `score_one` with the rect bbox; **every pixel in the clamped bbox is inside
+/// the rectangle**, so there is no per-pixel inside test. Matches `rasterize_rectangle_int` for an
+/// in-bounds rect (the production domain — `Rectangle` clamps its corners).
+#[cube]
+pub fn score_one_rect(
+    target: &Array<i32>,
+    current: &Array<i32>,
+    x1: i32,
+    y1: i32,
+    x2: i32,
+    y2: i32,
+    alpha: i32,
+    width: i32,
+    height: i32,
+) -> i32 {
+    let a_coef = 65535 / alpha;
+    let xa = if x1 < x2 { x1 } else { x2 };
+    let xb = if x1 < x2 { x2 } else { x1 };
+    let ya = if y1 < y2 { y1 } else { y2 };
+    let yb = if y1 < y2 { y2 } else { y1 };
+    let xmin = clampi(xa, 0, width - 1);
+    let xmax = clampi(xb, 0, width - 1);
+    let ymin = clampi(ya, 0, height - 1);
+    let ymax = clampi(yb, 0, height - 1);
+
+    let mut rsum = 0i32;
+    let mut gsum = 0i32;
+    let mut bsum = 0i32;
+    let mut count = 0i32;
+    for py in ymin..ymax + 1 {
+        for px in xmin..xmax + 1 {
+            let idx = ((py * width + px) * 4) as usize;
+            rsum += (target[idx] - current[idx]) * a_coef + current[idx] * 257;
+            gsum += (target[idx + 1] - current[idx + 1]) * a_coef + current[idx + 1] * 257;
+            bsum += (target[idx + 2] - current[idx + 2]) * a_coef + current[idx + 2] * 257;
+            count += 1;
+        }
+    }
+
+    let mut delta = 0i32;
+    if count > 0 {
+        let r = clamp_0_255((rsum / count) >> 8);
+        let g = clamp_0_255((gsum / count) >> 8);
+        let b = clamp_0_255((bsum / count) >> 8);
+        let av = alpha as u32;
+        let sr = ((r as u32) | ((r as u32) << 8)) * av / 255;
+        let sg = ((g as u32) | ((g as u32) << 8)) * av / 255;
+        let sb = ((b as u32) | ((b as u32) << 8)) * av / 255;
+        let sa = av | (av << 8);
+        let aa = (65535 - sa * 65535 / 65535) * 257;
+        for py in ymin..ymax + 1 {
+            for px in xmin..xmax + 1 {
+                let idx = ((py * width + px) * 4) as usize;
+                delta += channel_delta(target[idx], current[idx], sr, aa);
+                delta += channel_delta(target[idx + 1], current[idx + 1], sg, aa);
+                delta += channel_delta(target[idx + 2], current[idx + 2], sb, aa);
+                delta += channel_delta(target[idx + 3], current[idx + 3], sa, aa);
+            }
+        }
+    }
+    delta
+}
+
+/// GPU-2 batch scorer for ellipses. `ell` is 4 ints per candidate `[cx, cy, rx, ry]`; one thread
+/// per candidate. Output `out[c]` is the integer delta-SSE.
+#[cube(launch_unchecked)]
+pub fn score_ellipses(
+    target: &Array<i32>,
+    current: &Array<i32>,
+    ell: &Array<i32>,
+    alphas: &Array<i32>,
+    width: i32,
+    height: i32,
+    out: &mut Array<i32>,
+) {
+    let c = ABSOLUTE_POS;
+    if c < out.len() {
+        let base = c * 4;
+        out[c] = score_one_ellipse(
+            target,
+            current,
+            ell[base],
+            ell[base + 1],
+            ell[base + 2],
+            ell[base + 3],
+            alphas[c],
+            width,
+            height,
+        );
+    }
+}
+
+/// GPU-2 batch scorer for rectangles. `rects` is 4 ints per candidate `[x1, y1, x2, y2]`; one thread
+/// per candidate. Output `out[c]` is the integer delta-SSE.
+#[cube(launch_unchecked)]
+pub fn score_rectangles(
+    target: &Array<i32>,
+    current: &Array<i32>,
+    rects: &Array<i32>,
+    alphas: &Array<i32>,
+    width: i32,
+    height: i32,
+    out: &mut Array<i32>,
+) {
+    let c = ABSOLUTE_POS;
+    if c < out.len() {
+        let base = c * 4;
+        out[c] = score_one_rect(
+            target,
+            current,
+            rects[base],
+            rects[base + 1],
+            rects[base + 2],
+            rects[base + 3],
+            alphas[c],
+            width,
+            height,
+        );
+    }
+}

--- a/crates/primitive-gpu-cubecl/tests/gpu2_ellipses.rs
+++ b/crates/primitive-gpu-cubecl/tests/gpu2_ellipses.rs
@@ -37,7 +37,12 @@ fn gpu2_ellipse_raster_score_matches_cpu_exactly() {
     let mut cpu = Vec::with_capacity(N);
 
     for _ in 0..N {
-        let shape = Shape::random(ShapeType::Ellipse, W as i32, H as i32, &mut rng);
+        let mut shape = Shape::random(ShapeType::Ellipse, W as i32, H as i32, &mut rng);
+        // Mutate a few times so the gate exercises the larger-radii / near-edge-centre domain the
+        // CORE-3b.3 hill-climb will feed these kernels — not just freshly-rolled (rx,ry ≤ 32) shapes.
+        for _ in 0..4 {
+            shape.mutate(W as i32, H as i32, &mut rng);
+        }
         let [cx, cy, rx, ry] = shape.ellipse_coords();
         buf.clear();
         rasterize_ellipse_int(cx, cy, rx, ry, W as i32, H as i32, &mut buf);

--- a/crates/primitive-gpu-cubecl/tests/gpu2_ellipses.rs
+++ b/crates/primitive-gpu-cubecl/tests/gpu2_ellipses.rs
@@ -1,0 +1,72 @@
+//! CORE-3b.2 gate: the GPU `score_ellipses` kernel (in-kernel integer ellipse raster + closed-form
+//! color + integer delta-SSE) == the CPU integer path (`rasterize_ellipse_int` +
+//! `candidate_color_and_delta`) **exactly** for 1000 random ellipse candidates. The same bit-exact
+//! parity the triangle scorer holds (`gpu2_triangles.rs`), now for ellipses — the GPU-resident
+//! foundation the CORE-3b.3 ellipse search loop builds on.
+
+use primitive_core::{
+    candidate_color_and_delta, rasterize_ellipse_int, Canvas, Rng, Shape, ShapeType,
+};
+use primitive_gpu_cubecl::{gpu_score_ellipses, EllipseBatch};
+
+const W: usize = 64;
+const H: usize = 64;
+const ALPHA: i32 = 128;
+const N: usize = 1000;
+
+fn target_canvas() -> Canvas {
+    let mut target = Canvas::new(W, H);
+    for (k, px) in target.pix.chunks_exact_mut(4).enumerate() {
+        px[0] = (k * 7 % 256) as u8;
+        px[1] = (k * 13 % 256) as u8;
+        px[2] = (k % 256) as u8;
+        px[3] = 255;
+    }
+    target
+}
+
+#[test]
+fn gpu2_ellipse_raster_score_matches_cpu_exactly() {
+    let target = target_canvas();
+    let current = Canvas::filled(W, H, 120, 110, 100);
+    let mut rng = Rng::new(7);
+    let mut scratch = Canvas::new(W, H);
+    let mut buf = Vec::new();
+    let mut ells = Vec::with_capacity(N * 4);
+    let mut alphas = Vec::with_capacity(N);
+    let mut cpu = Vec::with_capacity(N);
+
+    for _ in 0..N {
+        let shape = Shape::random(ShapeType::Ellipse, W as i32, H as i32, &mut rng);
+        let [cx, cy, rx, ry] = shape.ellipse_coords();
+        buf.clear();
+        rasterize_ellipse_int(cx, cy, rx, ry, W as i32, H as i32, &mut buf);
+        let (_color, delta) =
+            candidate_color_and_delta(&target, &current, &buf, ALPHA, &mut scratch);
+        cpu.push(delta);
+        ells.extend_from_slice(&[cx, cy, rx, ry]);
+        alphas.push(ALPHA);
+    }
+
+    let gpu = gpu_score_ellipses(&target, &current, &EllipseBatch { ells, alphas });
+    assert_eq!(gpu.len(), N);
+
+    let mut mismatches = 0;
+    for i in 0..N {
+        if gpu[i] as i64 != cpu[i] {
+            if mismatches < 5 {
+                eprintln!("ellipse {i}: gpu={} cpu={}", gpu[i], cpu[i]);
+            }
+            mismatches += 1;
+        }
+    }
+    println!(
+        "CORE-3b.2 on-device ellipse raster+score: {}/{} candidates bit-identical to CPU integer path",
+        N - mismatches,
+        N
+    );
+    assert_eq!(
+        mismatches, 0,
+        "{mismatches}/{N} mismatched (on-device integer ellipse path must be exact)"
+    );
+}

--- a/crates/primitive-gpu-cubecl/tests/gpu2_rects.rs
+++ b/crates/primitive-gpu-cubecl/tests/gpu2_rects.rs
@@ -1,0 +1,71 @@
+//! CORE-3b.2 gate: the GPU `score_rectangles` kernel (in-kernel integer rect raster + closed-form
+//! color + integer delta-SSE) == the CPU integer path (`rasterize_rectangle_int` +
+//! `candidate_color_and_delta`) **exactly** for 1000 random rectangle candidates. The same bit-exact
+//! parity the triangle scorer holds (`gpu2_triangles.rs`), now for rectangles.
+
+use primitive_core::{
+    candidate_color_and_delta, rasterize_rectangle_int, Canvas, Rng, Shape, ShapeType,
+};
+use primitive_gpu_cubecl::{gpu_score_rectangles, RectBatch};
+
+const W: usize = 64;
+const H: usize = 64;
+const ALPHA: i32 = 128;
+const N: usize = 1000;
+
+fn target_canvas() -> Canvas {
+    let mut target = Canvas::new(W, H);
+    for (k, px) in target.pix.chunks_exact_mut(4).enumerate() {
+        px[0] = (k * 7 % 256) as u8;
+        px[1] = (k * 13 % 256) as u8;
+        px[2] = (k % 256) as u8;
+        px[3] = 255;
+    }
+    target
+}
+
+#[test]
+fn gpu2_rect_raster_score_matches_cpu_exactly() {
+    let target = target_canvas();
+    let current = Canvas::filled(W, H, 120, 110, 100);
+    let mut rng = Rng::new(7);
+    let mut scratch = Canvas::new(W, H);
+    let mut buf = Vec::new();
+    let mut rects = Vec::with_capacity(N * 4);
+    let mut alphas = Vec::with_capacity(N);
+    let mut cpu = Vec::with_capacity(N);
+
+    for _ in 0..N {
+        let shape = Shape::random(ShapeType::Rectangle, W as i32, H as i32, &mut rng);
+        let [x1, y1, x2, y2] = shape.rectangle_coords();
+        buf.clear();
+        rasterize_rectangle_int(x1, y1, x2, y2, W as i32, H as i32, &mut buf);
+        let (_color, delta) =
+            candidate_color_and_delta(&target, &current, &buf, ALPHA, &mut scratch);
+        cpu.push(delta);
+        rects.extend_from_slice(&[x1, y1, x2, y2]);
+        alphas.push(ALPHA);
+    }
+
+    let gpu = gpu_score_rectangles(&target, &current, &RectBatch { rects, alphas });
+    assert_eq!(gpu.len(), N);
+
+    let mut mismatches = 0;
+    for i in 0..N {
+        if gpu[i] as i64 != cpu[i] {
+            if mismatches < 5 {
+                eprintln!("rect {i}: gpu={} cpu={}", gpu[i], cpu[i]);
+            }
+            mismatches += 1;
+        }
+    }
+    println!(
+        "CORE-3b.2 on-device rect raster+score: {}/{} candidates bit-identical to CPU integer path",
+        N - mismatches,
+        N
+    );
+    assert_eq!(
+        mismatches, 0,
+        "{mismatches}/{N} mismatched (on-device integer rect path must be exact)"
+    );
+}

--- a/crates/primitive-gpu-cubecl/tests/gpu2_rects.rs
+++ b/crates/primitive-gpu-cubecl/tests/gpu2_rects.rs
@@ -36,7 +36,12 @@ fn gpu2_rect_raster_score_matches_cpu_exactly() {
     let mut cpu = Vec::with_capacity(N);
 
     for _ in 0..N {
-        let shape = Shape::random(ShapeType::Rectangle, W as i32, H as i32, &mut rng);
+        let mut shape = Shape::random(ShapeType::Rectangle, W as i32, H as i32, &mut rng);
+        // Mutate a few times so the gate exercises the larger / near-edge rects the CORE-3b.3
+        // hill-climb will feed these kernels — not just freshly-rolled shapes.
+        for _ in 0..4 {
+            shape.mutate(W as i32, H as i32, &mut rng);
+        }
         let [x1, y1, x2, y2] = shape.rectangle_coords();
         buf.clear();
         rasterize_rectangle_int(x1, y1, x2, y2, W as i32, H as i32, &mut buf);


### PR DESCRIPTION
## Summary

The GPU can now **rasterize + score ellipse & rectangle candidates on-device, bit-exact against the CPU oracle** — the proven GPU-2 triangle path generalized to the new shapes (consuming CORE-3b.1's integer rasterizers in-kernel).

## What's in

New module **`score_shapes.rs`** (keeps `kernels.rs` under the 500-LOC gate):
- **`inside_ellipse`** (`#[cube]`) mirrors `raster_int::ellipse_inside` in i32 (overflow-free ≤128px — the degree-4 product peaks ~4× under i32::MAX).
- **`score_one_ellipse`** / **`score_one_rect`** mirror `kernels::score_one` (closed-form color + 16-bit premultiplied composite + integer delta-SSE), swapping in the ellipse bbox + `inside_ellipse` / the rect bbox (every bbox pixel is inside, no per-pixel test). They reuse the proven `channel_delta`/`clamp_0_255` helpers, so the parity that holds for triangles carries by construction.
- **`score_ellipses`** / **`score_rectangles`** batch kernels (4 ints/candidate, one thread each).

Host: `EllipseBatch`/`RectBatch` + `GpuSession::score_ellipses`/`score_rects` + one-shot `gpu_score_ellipses`/`gpu_score_rectangles`. New `Shape::ellipse_coords()`/`rectangle_coords()` accessors (the flat `[cx,cy,rx,ry]`/`[x1,y1,x2,y2]` layouts the kernels consume).

## Gate (green in `make verify`, on Metal)

- **`gpu2_ellipses.rs`** — `score_ellipses` == `rasterize_ellipse_int` + `candidate_color_and_delta`, **1000/1000 candidates bit-identical** to the CPU integer path.
- **`gpu2_rects.rs`** — `score_rectangles` == `rasterize_rectangle_int` + `candidate_color_and_delta`, **1000/1000 candidates bit-identical**.

## Cleanup folded in

3b.1 review NIT: `shape.rs`'s private `clamp_i32` removed — now uses the shared `raster::clamp_i32` (`pub(crate)`).

## Follow-up

Scorer only. **CORE-3b.3** generalizes the GPU *search loop* (`search::evolve`/`commit` — in-kernel random/mutate per shape type) so the app's GPU instant mode can drop the triangle-only guard and run ellipse/rect fully on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)