### PR TITLE
feat(gpu): CORE-3 Part B.3 — on-device search loop for ellipse + rectangle

### DIFF
--- a/.agent/EVIDENCE.md
+++ b/.agent/EVIDENCE.md
@@ -276,3 +276,18 @@ search will feed, not just freshly-rolled shapes). Host: `EllipseBatch`/`RectBat
 correct-by-precondition): the kernels now `.abs()` radii + drop fully-off-canvas rects like their CPU
 oracles, and `score_ellipses` `debug_assert`s the ≤182-px i32-safe canvas bound at dispatch. Scorer
 only — the GPU search loop (`evolve`/`commit`) is CORE-3b.3.
+
+## CORE-3 Part B.3 — on-device search loop for ellipse + rectangle (2026-06-30)
+
+### GPU-native ellipse/rect search ≈ CPU quality — `crates/primitive-gpu-cubecl/tests/`
+```
+gpu3_ellipse_optimize.rs::gpu3_ellipse_search_matches_cpu_psnr ... ok  CPU 34.31 dB | GPU 33.99 dB | gap -0.32 dB
+gpu3_rect_optimize.rs::gpu3_rect_search_matches_cpu_psnr ......... ok  CPU 35.50 dB | GPU 35.13 dB | gap -0.37 dB
+make verify ..................................................... verify: ALL GREEN (on Metal)
+```
+80 shapes, 64×64. `evolve_ellipse`/`evolve_rect` + `commit_ellipse`/`commit_rect` (new
+`search_shapes.rs`) run the whole search GPU-resident: energy-anchored, Rechenberg 1/5 self-adaptive
+hill-climb over the shape params (all clamped to the canvas → i32-safe), scored by the parity-exact
+`score_one_ellipse`/`score_one_rect`, committed over the same coverage. Independent of the CPU search
+(GPU-native), so compared by **PSNR within 1.0 dB** — both land within 0.4 dB. `OptConfig.shape_type`
+selects the kernel triplet in `gpu_optimize`. **CORE-3b complete**: the GPU fits all three shapes.

--- a/.agent/PROGRESS.md
+++ b/.agent/PROGRESS.md
@@ -218,11 +218,12 @@ Gate evidence (all green in `make verify`; `crates/primitive-core/tests/shapes.r
   flat-background baseline** (PSNR 32.15 / 33.07 dB); SVG export emits valid `<ellipse>` / `<rect>`.
 
 Scope notes (carry-forward, by design):
-- **CORE-3b (GPU)**: staged in three. **3b.1 (integer rasterizers) + 3b.2 (on-device score kernels)
-  ✅ DONE** — see Part B.1 / B.2 below. **3b.3 remains**: the GPU *search loop* (`evolve`/`commit`) is
-  still triangle-specific (in-kernel random/mutate over 6-int triangles), so GPU instant mode in the app
-  stays triangle-only (`runner::should_use_gpu`). 3b.3 = generalize `evolve`/`commit` (in-kernel
-  random/mutate + the scanline scorer per shape type) so ellipse/rect get the full on-device search.
+- **CORE-3b (GPU) ✅ DONE** (all three): **3b.1** integer rasterizers, **3b.2** on-device score kernels,
+  **3b.3** on-device search loop (`evolve_ellipse`/`evolve_rect` + `commit_*`) — see Part B.1/B.2/B.3.
+  The GPU now fits triangles, ellipses, and rects fully on-device (gated by PSNR within tolerance of the
+  CPU search). The app keeps routing ellipse/rect to the CPU streaming path by default (it preserves the
+  SVG export + live spectacle the raster-only GPU instant mode can't) — flipping `runner::should_use_gpu`
+  to offer a GPU fast-preview for the new shapes is now a one-line guard change, deferred as a UX call.
 - **CORE-3c (GUI)**: ✅ DONE — see the Part C section below.
 - **CORE-3a.2 (rigour)**: fogleman **bit-exact** parity for ellipse/rect needs the Go dumper
   (`go_primitive/primitive/parity_dump_test.go`, schema is triangle-only) extended; until then the
@@ -323,3 +324,29 @@ Cleanup folded in (3b.1 review NIT): `shape.rs`'s private `clamp_i32` removed �
 Carry-forward: this is the **scorer** only. CORE-3b.3 generalizes the GPU *search loop*
 (`search::evolve`/`commit` — in-kernel random/mutate per shape type) so the app's GPU instant mode can
 drop the triangle-only guard and run ellipse/rect fully on-device.
+
+## CORE-3 Part B.3 — on-device search loop for ellipse + rectangle — ✅ DONE (2026-06-30)
+
+The **whole search runs GPU-resident** for ellipses and rects now, not just triangles — the GPU-3
+triangle loop generalized. New module `crates/primitive-gpu-cubecl/src/search_shapes.rs`:
+
+- **`evolve_ellipse`** / **`evolve_rect`** — one independent hill-climb per worker: a shared
+  energy-targeted `anchor` (best-of-8 high-residual pixels) seeds the centre/first-corner; small random
+  radii / opposite corner; then `age` **Rechenberg 1/5 self-adaptive** perturbations of one param
+  (`{cx,cy,rx,ry}` / the four corners), each clamped to the canvas (radii to `[1,w-1]` — keeps the i32
+  ellipse test overflow-safe, §6.6), keeping a change only if it lowers the delta-SSE (scored by the
+  parity-exact `score_one_ellipse`/`score_one_rect`). Writes best delta + best 4-int params.
+- **`commit_ellipse`** / **`commit_rect`** — fused argmin + composite the improving step winner over the
+  bbox+`inside_ellipse` / bbox coverage, in place, no host sync. Mirrors triangle `commit`.
+- Host: `OptConfig.shape_type` selects the kernel triplet; `gpu_optimize` matches on it (best-param
+  buffer 6 ints for triangle, 4 for ellipse/rect). Like GPU-3, the GPU is a **native** optimizer, not a
+  replay of the CPU search — compared by **PSNR**, not pixels.
+
+Gate evidence (hardware-independent → unconditional in `make verify`):
+- **`gpu3_ellipse_optimize.rs`** — 80 shapes, 64×64: **GPU 33.99 dB vs CPU 34.31 dB, gap −0.32 dB**
+  (≤ 1.0 dB tolerance).
+- **`gpu3_rect_optimize.rs`** — 80 shapes, 64×64: **GPU 35.13 dB vs CPU 35.50 dB, gap −0.37 dB**.
+
+App: `runner::gpu_instant` plumbs `cfg.shape_type` into `OptConfig`; the `should_use_gpu` guard stays
+triangle-only by choice (ellipse/rect keep the CPU path's SVG + streaming). **CORE-3b is complete** —
+the GPU fits all three shapes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,12 +45,13 @@ core (pure) ← compute (ports) ← engine (orchestration) ← adapters / app (c
 - **GPU-1/2/3** — integer-SSE parity + on-device search in `crates/primitive-gpu-cubecl/tests/*` (Metal; `make verify` runs them). The **throughput** thresholds (GPU-2 ≥20×, GPU-3 ≥460 sps) are hardware-dependent → enforced by `make perf`, not `make verify` (see `tests/common/mod.rs`); the PSNR + integer-parity gates stay in `make verify`.
 - **CORE-3 Part A** (Ellipse + Rectangle, core + CPU) — `crates/primitive-core/tests/shapes.rs` (rasterizer geometry, determinism, effectiveness). `Shape::triangle_coords()` panics for non-triangles until the GPU kernels generalize (CORE-3b).
 - **CORE-3 Part B.1** (integer ellipse/rect rasterizers, the GPU-shared §6.6 path) — `crates/primitive-core/src/raster_int.rs` (new module; f64 golden reference stays in `raster.rs`). `ellipse_inside` = integer implicit test `ry²·dx²+rx²·dy² ≤ rx²·ry²`; `rasterize_ellipse_int`/`rasterize_rectangle_int`.
-- **CORE-3 Part B.2** (on-device ellipse/rect score kernels) — `crates/primitive-gpu-cubecl/src/score_shapes.rs` (`score_ellipses`/`score_rectangles`), tests `gpu2_ellipses.rs`/`gpu2_rects.rs` (1000/1000 bit-identical to the CPU integer path on Metal). The GPU *search loop* (`evolve`/`commit`) stays triangle-only until CORE-3b.3, so app GPU instant mode is still triangle-only.
+- **CORE-3 Part B.2** (on-device ellipse/rect score kernels) — `crates/primitive-gpu-cubecl/src/score_shapes.rs` (`score_ellipses`/`score_rectangles`), tests `gpu2_ellipses.rs`/`gpu2_rects.rs` (1000/1000 bit-identical to the CPU integer path on Metal).
+- **CORE-3 Part B.3** (on-device ellipse/rect search loop) — `crates/primitive-gpu-cubecl/src/search_shapes.rs` (`evolve_ellipse`/`evolve_rect` + `commit_*`), `OptConfig.shape_type` dispatched in `gpu_optimize`; gates `gpu3_ellipse_optimize.rs`/`gpu3_rect_optimize.rs` (GPU PSNR within 0.4 dB of CPU). **CORE-3b complete** — GPU fits all 3 shapes. App routing stays CPU for ellipse/rect (keeps SVG + streaming); GPU instant for them is a one-line `should_use_gpu` change away.
 - **CORE-3 Part C** (GUI shape selector) — `crates/primitive-app/tests/e2e.rs` (ellipse run → `<ellipse>` SVG), `runner::tests` (pure `should_use_gpu` routing guard), `a11y_tree.rs` (all three options in the AccessKit tree + click mutates selection). `ShapeType` is selectable + persisted; GPU instant mode stays triangle-only (CORE-3b).
 - **GUI-2** — the §5A interaction gates in `crates/primitive-app/tests/*` (`state_suite` pure-state matrix,
   `e2e` load→100→SVG, `forced_cpu` device chip, `a11y_tree` AccessKit, `a11y_tokens` WCAG/Reduce-Motion).
 
-Full milestone state (CORE-1/2 · GPU-1/2/3 · GUI-1/2 · PKG-1 Part A · CORE-3 Part A+B.1+B.2+C — all ✅) lives in `.agent/PROGRESS.md` + `.agent/EVIDENCE.md`.
+Full milestone state (CORE-1/2 · GPU-1/2/3 · GUI-1/2 · PKG-1 Part A · CORE-3 complete: A+B.1+B.2+B.3+C — all ✅) lives in `.agent/PROGRESS.md` + `.agent/EVIDENCE.md`.
 
 ## Rules for changes here
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ This repository contains three implementations of the Primitive algorithm:
 A from-scratch Rust rewrite (hexagonal crates under [`crates/`](crates/)) that runs the whole search on the
 GPU via CubeCL→Metal with **bitwise-deterministic integer scoring**, plus a one-window `eframe` desktop app
 whose hero is the live reconstruction canvas. Shapes: triangle, ellipse, and axis-aligned rectangle —
-selectable in the app, running live on the CPU path (GPU kernels for ellipse/rect are the next core slice;
-rotated/curved variants follow). Spec + status: [`docs/plan/primitive-2026-architecture.md`](docs/plan/primitive-2026-architecture.md),
+selectable in the app, fitted on both the CPU path and fully on-device on the GPU (rotated/curved variants
+follow). Spec + status: [`docs/plan/primitive-2026-architecture.md`](docs/plan/primitive-2026-architecture.md),
 [`AGENTS.md`](AGENTS.md), [`.agent/PROGRESS.md`](.agent/PROGRESS.md).
 
 ```bash

--- a/crates/primitive-app/src/runner.rs
+++ b/crates/primitive-app/src/runner.rs
@@ -153,6 +153,9 @@ fn gpu_instant(cfg: RunConfig, tx: &Sender<Frame>) {
         shapes: cfg.count,
         alpha: cfg.alpha,
         seed: cfg.seed as u32,
+        // Always Triangle today (`should_use_gpu` routes only triangles here); plumbed by value so
+        // the GPU ellipse/rect search (CORE-3b.3) is one guard-change away from a fast-preview mode.
+        shape_type: cfg.shape_type,
     };
     let start = Instant::now();
     let result =

--- a/crates/primitive-gpu-cubecl/examples/sweep.rs
+++ b/crates/primitive-gpu-cubecl/examples/sweep.rs
@@ -66,6 +66,7 @@ fn main() {
             shapes: 2,
             alpha,
             seed: 9,
+            shape_type: ShapeType::Triangle,
         },
     );
 
@@ -86,6 +87,7 @@ fn main() {
             shapes,
             alpha,
             seed: 1,
+            shape_type: ShapeType::Triangle,
         };
         let t = Instant::now();
         let recon = gpu_optimize(&target, &cfg);

--- a/crates/primitive-gpu-cubecl/src/lib.rs
+++ b/crates/primitive-gpu-cubecl/src/lib.rs
@@ -292,6 +292,13 @@ pub fn gpu_optimize(target: &Canvas, cfg: &OptConfig) -> Canvas {
     let n_pix = target_i32.len();
     let w = target.w as i32;
     let h = target.h as i32;
+    // The ellipse/rect search reaches `inside_ellipse`'s i32 degree-4 product, which overflows once a
+    // radius exceeds ~181 (radii clamp to `w-1`/`h-1`). Mirrors the `score_ellipses` dispatch guard;
+    // triangles use the edge-function path and aren't bound by it. The app caps at GPU_INSTANT_MAX=128.
+    debug_assert!(
+        cfg.shape_type == ShapeType::Triangle || (w <= 182 && h <= 182),
+        "gpu_optimize: {w}×{h} exceeds the i32-safe ellipse/rect bound (§6.6)"
+    );
 
     let client = WgpuRuntime::client(&Default::default());
     let target_h = client.create_from_slice(bytemuck::cast_slice(&target_i32));

--- a/crates/primitive-gpu-cubecl/src/lib.rs
+++ b/crates/primitive-gpu-cubecl/src/lib.rs
@@ -19,11 +19,12 @@
 mod kernels;
 mod score_shapes;
 mod search;
+mod search_shapes;
 
 use cubecl::prelude::*;
 use cubecl::server::Handle;
 use cubecl::wgpu::WgpuRuntime;
-use primitive_core::Canvas;
+use primitive_core::{Canvas, ShapeType};
 
 const THREADS: u32 = 64;
 
@@ -272,6 +273,9 @@ pub struct OptConfig {
     pub shapes: usize,
     pub alpha: i32,
     pub seed: u32,
+    /// Which primitive to fit. Triangle uses the 6-int `evolve`/`commit`; ellipse/rect the 4-int
+    /// `evolve_ellipse`/`evolve_rect` + matching commit (CORE-3b.3).
+    pub shape_type: ShapeType,
 }
 
 /// GPU-3: run the whole search loop on-device and return the final reconstruction.
@@ -293,39 +297,114 @@ pub fn gpu_optimize(target: &Canvas, cfg: &OptConfig) -> Canvas {
     let target_h = client.create_from_slice(bytemuck::cast_slice(&target_i32));
     let current_h = client.create_from_slice(bytemuck::cast_slice(&current_i32));
     let best_delta_h = client.empty(cfg.workers * core::mem::size_of::<i32>());
-    let best_tri_h = client.empty(cfg.workers * 6 * core::mem::size_of::<i32>());
+    // 6 ints/worker for a triangle, 4 for an ellipse/rect.
+    let stride = if cfg.shape_type == ShapeType::Triangle {
+        6
+    } else {
+        4
+    };
+    let best_param_h = client.empty(cfg.workers * stride * core::mem::size_of::<i32>());
+    let plen = cfg.workers * stride;
+    let evolve_cubes = CubeCount::Static((cfg.workers as u32).div_ceil(THREADS), 1, 1);
+    let evolve_dim = CubeDim::new_1d(THREADS);
+    let commit_cubes = CubeCount::Static(1, 1, 1);
+    let commit_dim = CubeDim::new_1d(1);
 
     for step in 0..cfg.shapes {
         unsafe {
-            search::evolve::launch_unchecked::<WgpuRuntime>(
-                &client,
-                CubeCount::Static((cfg.workers as u32).div_ceil(THREADS), 1, 1),
-                CubeDim::new_1d(THREADS),
-                ArrayArg::from_raw_parts(target_h.clone(), n_pix),
-                ArrayArg::from_raw_parts(current_h.clone(), n_pix),
-                cfg.seed,
-                step as u32,
-                cfg.alpha,
-                w,
-                h,
-                cfg.age,
-                ArrayArg::from_raw_parts(best_delta_h.clone(), cfg.workers),
-                ArrayArg::from_raw_parts(best_tri_h.clone(), cfg.workers * 6),
-            );
-            // commit fuses the argmin (over best_delta) + composite — one launch, not two.
-            search::commit::launch_unchecked::<WgpuRuntime>(
-                &client,
-                CubeCount::Static(1, 1, 1),
-                CubeDim::new_1d(1),
-                ArrayArg::from_raw_parts(target_h.clone(), n_pix),
-                ArrayArg::from_raw_parts(current_h.clone(), n_pix),
-                ArrayArg::from_raw_parts(best_tri_h.clone(), cfg.workers * 6),
-                ArrayArg::from_raw_parts(best_delta_h.clone(), cfg.workers),
-                cfg.workers as i32,
-                cfg.alpha,
-                w,
-                h,
-            );
+            match cfg.shape_type {
+                ShapeType::Triangle => {
+                    search::evolve::launch_unchecked::<WgpuRuntime>(
+                        &client,
+                        evolve_cubes.clone(),
+                        evolve_dim,
+                        ArrayArg::from_raw_parts(target_h.clone(), n_pix),
+                        ArrayArg::from_raw_parts(current_h.clone(), n_pix),
+                        cfg.seed,
+                        step as u32,
+                        cfg.alpha,
+                        w,
+                        h,
+                        cfg.age,
+                        ArrayArg::from_raw_parts(best_delta_h.clone(), cfg.workers),
+                        ArrayArg::from_raw_parts(best_param_h.clone(), plen),
+                    );
+                    // commit fuses the argmin (over best_delta) + composite — one launch, not two.
+                    search::commit::launch_unchecked::<WgpuRuntime>(
+                        &client,
+                        commit_cubes.clone(),
+                        commit_dim,
+                        ArrayArg::from_raw_parts(target_h.clone(), n_pix),
+                        ArrayArg::from_raw_parts(current_h.clone(), n_pix),
+                        ArrayArg::from_raw_parts(best_param_h.clone(), plen),
+                        ArrayArg::from_raw_parts(best_delta_h.clone(), cfg.workers),
+                        cfg.workers as i32,
+                        cfg.alpha,
+                        w,
+                        h,
+                    );
+                }
+                ShapeType::Ellipse => {
+                    search_shapes::evolve_ellipse::launch_unchecked::<WgpuRuntime>(
+                        &client,
+                        evolve_cubes.clone(),
+                        evolve_dim,
+                        ArrayArg::from_raw_parts(target_h.clone(), n_pix),
+                        ArrayArg::from_raw_parts(current_h.clone(), n_pix),
+                        cfg.seed,
+                        step as u32,
+                        cfg.alpha,
+                        w,
+                        h,
+                        cfg.age,
+                        ArrayArg::from_raw_parts(best_delta_h.clone(), cfg.workers),
+                        ArrayArg::from_raw_parts(best_param_h.clone(), plen),
+                    );
+                    search_shapes::commit_ellipse::launch_unchecked::<WgpuRuntime>(
+                        &client,
+                        commit_cubes.clone(),
+                        commit_dim,
+                        ArrayArg::from_raw_parts(target_h.clone(), n_pix),
+                        ArrayArg::from_raw_parts(current_h.clone(), n_pix),
+                        ArrayArg::from_raw_parts(best_param_h.clone(), plen),
+                        ArrayArg::from_raw_parts(best_delta_h.clone(), cfg.workers),
+                        cfg.workers as i32,
+                        cfg.alpha,
+                        w,
+                        h,
+                    );
+                }
+                ShapeType::Rectangle => {
+                    search_shapes::evolve_rect::launch_unchecked::<WgpuRuntime>(
+                        &client,
+                        evolve_cubes.clone(),
+                        evolve_dim,
+                        ArrayArg::from_raw_parts(target_h.clone(), n_pix),
+                        ArrayArg::from_raw_parts(current_h.clone(), n_pix),
+                        cfg.seed,
+                        step as u32,
+                        cfg.alpha,
+                        w,
+                        h,
+                        cfg.age,
+                        ArrayArg::from_raw_parts(best_delta_h.clone(), cfg.workers),
+                        ArrayArg::from_raw_parts(best_param_h.clone(), plen),
+                    );
+                    search_shapes::commit_rect::launch_unchecked::<WgpuRuntime>(
+                        &client,
+                        commit_cubes.clone(),
+                        commit_dim,
+                        ArrayArg::from_raw_parts(target_h.clone(), n_pix),
+                        ArrayArg::from_raw_parts(current_h.clone(), n_pix),
+                        ArrayArg::from_raw_parts(best_param_h.clone(), plen),
+                        ArrayArg::from_raw_parts(best_delta_h.clone(), cfg.workers),
+                        cfg.workers as i32,
+                        cfg.alpha,
+                        w,
+                        h,
+                    );
+                }
+            }
         }
     }
 

--- a/crates/primitive-gpu-cubecl/src/score_shapes.rs
+++ b/crates/primitive-gpu-cubecl/src/score_shapes.rs
@@ -15,7 +15,7 @@ use crate::kernels::{channel_delta, clamp_0_255, clampi};
 /// (`ry²·dx² + rx²·dy² ≤ rx²·ry²`, no `sqrt`). i32; overflow-free within the ≤128-px canvas bound
 /// (the degree-4 product peaks at `2·128⁴ ≈ 5.4e8`, ~4× under i32::MAX — §6.6).
 #[cube]
-fn inside_ellipse(cx: i32, cy: i32, rx: i32, ry: i32, px: i32, py: i32) -> bool {
+pub(crate) fn inside_ellipse(cx: i32, cy: i32, rx: i32, ry: i32, px: i32, py: i32) -> bool {
     let dx = px - cx;
     let dy = py - cy;
     ry * ry * dx * dx + rx * rx * dy * dy <= rx * rx * ry * ry

--- a/crates/primitive-gpu-cubecl/src/search.rs
+++ b/crates/primitive-gpu-cubecl/src/search.rs
@@ -12,7 +12,13 @@ use cubecl::prelude::*;
 /// steers toward. L2 (matches `core::energy_map::residual_map`) biases harder toward hot pixels than
 /// L1 did, so the best-of-N anchor lands nearer the real error peaks. Max 3·255² = 195075, fits i32.
 #[cube]
-fn residual(target: &Array<i32>, current: &Array<i32>, px: i32, py: i32, width: i32) -> i32 {
+pub(crate) fn residual(
+    target: &Array<i32>,
+    current: &Array<i32>,
+    px: i32,
+    py: i32,
+    width: i32,
+) -> i32 {
     let idx = ((py * width + px) * 4) as usize;
     let dr = target[idx] - current[idx];
     let dg = target[idx + 1] - current[idx + 1];

--- a/crates/primitive-gpu-cubecl/src/search.rs
+++ b/crates/primitive-gpu-cubecl/src/search.rs
@@ -156,8 +156,9 @@ pub fn evolve(
         let s = rand_u32(seed + step, w as u32);
         let mut ctr = 1u32;
 
-        // Energy-targeted anchor: the highest-residual of 4 random pixels (cheap restart bias
-        // toward error-heavy regions — fogleman's energy-map trick, sampled).
+        // Energy-targeted anchor: the highest-residual of 8 random pixels (cheap restart bias
+        // toward error-heavy regions — fogleman's energy-map trick, sampled). Same best-of-8 the
+        // shared `search_shapes::anchor` helper factors out for the ellipse/rect loops.
         let mut x0 = rand_below(s, ctr, width as u32) as i32;
         ctr += 1;
         let mut y0 = rand_below(s, ctr, height as u32) as i32;

--- a/crates/primitive-gpu-cubecl/src/search_shapes.rs
+++ b/crates/primitive-gpu-cubecl/src/search_shapes.rs
@@ -230,10 +230,15 @@ pub fn commit_ellipse(
             let rx = best_ell[b + 2];
             let ry = best_ell[b + 3];
             let a_coef = 65535 / alpha;
-            let xmin = clampi(cx - rx, 0, width - 1);
-            let xmax = clampi(cx + rx, 0, width - 1);
-            let ymin = clampi(cy - ry, 0, height - 1);
-            let ymax = clampi(cy + ry, 0, height - 1);
+            // Mirror `score_one_ellipse`'s `arx/ary` abs so commit composites over the *exact* coverage
+            // evolve scored (radii are ≥ 1 today → no-op precondition, kept so the kernel is a true
+            // mirror of its scorer rather than correct only by precondition).
+            let arx = if rx < 0 { -rx } else { rx };
+            let ary = if ry < 0 { -ry } else { ry };
+            let xmin = clampi(cx - arx, 0, width - 1);
+            let xmax = clampi(cx + arx, 0, width - 1);
+            let ymin = clampi(cy - ary, 0, height - 1);
+            let ymax = clampi(cy + ary, 0, height - 1);
 
             let mut rsum = 0i32;
             let mut gsum = 0i32;
@@ -241,7 +246,7 @@ pub fn commit_ellipse(
             let mut count = 0i32;
             for py in ymin..ymax + 1 {
                 for px in xmin..xmax + 1 {
-                    if inside_ellipse(cx, cy, rx, ry, px, py) {
+                    if inside_ellipse(cx, cy, arx, ary, px, py) {
                         let idx = ((py * width + px) * 4) as usize;
                         rsum += (target[idx] - current[idx]) * a_coef + current[idx] * 257;
                         gsum +=
@@ -264,7 +269,7 @@ pub fn commit_ellipse(
                 let aa = (65535 - sa * 65535 / 65535) * 257;
                 for py in ymin..ymax + 1 {
                     for px in xmin..xmax + 1 {
-                        if inside_ellipse(cx, cy, rx, ry, px, py) {
+                        if inside_ellipse(cx, cy, arx, ary, px, py) {
                             let idx = ((py * width + px) * 4) as usize;
                             current[idx] = composite(current[idx] as u32, sr, aa) as i32;
                             current[idx + 1] = composite(current[idx + 1] as u32, sg, aa) as i32;
@@ -311,6 +316,9 @@ pub fn commit_rect(
             let xb = if rx1 < rx2 { rx2 } else { rx1 };
             let ya = if ry1 < ry2 { ry1 } else { ry2 };
             let yb = if ry1 < ry2 { ry2 } else { ry1 };
+            // Mirror `score_one_rect`'s off-canvas drop so commit composites over the *exact* coverage
+            // evolve scored (corners clamp in-bounds today → always true, kept for parity).
+            let in_bounds = xb >= 0 && xa < width && yb >= 0 && ya < height;
             let a_coef = 65535 / alpha;
             let xmin = clampi(xa, 0, width - 1);
             let xmax = clampi(xb, 0, width - 1);
@@ -321,13 +329,17 @@ pub fn commit_rect(
             let mut gsum = 0i32;
             let mut bsum = 0i32;
             let mut count = 0i32;
-            for py in ymin..ymax + 1 {
-                for px in xmin..xmax + 1 {
-                    let idx = ((py * width + px) * 4) as usize;
-                    rsum += (target[idx] - current[idx]) * a_coef + current[idx] * 257;
-                    gsum += (target[idx + 1] - current[idx + 1]) * a_coef + current[idx + 1] * 257;
-                    bsum += (target[idx + 2] - current[idx + 2]) * a_coef + current[idx + 2] * 257;
-                    count += 1;
+            if in_bounds {
+                for py in ymin..ymax + 1 {
+                    for px in xmin..xmax + 1 {
+                        let idx = ((py * width + px) * 4) as usize;
+                        rsum += (target[idx] - current[idx]) * a_coef + current[idx] * 257;
+                        gsum +=
+                            (target[idx + 1] - current[idx + 1]) * a_coef + current[idx + 1] * 257;
+                        bsum +=
+                            (target[idx + 2] - current[idx + 2]) * a_coef + current[idx + 2] * 257;
+                        count += 1;
+                    }
                 }
             }
             if count > 0 {

--- a/crates/primitive-gpu-cubecl/src/search_shapes.rs
+++ b/crates/primitive-gpu-cubecl/src/search_shapes.rs
@@ -1,0 +1,355 @@
+//! CORE-3b.3 — on-device search loop (`evolve` + `commit`) for **ellipse** & **rectangle**.
+//!
+//! Generalizes the triangle GPU-3 loop in [`crate::search`] to the new shapes. Each is a GPU-*native*
+//! optimizer (energy-targeted restart + Rechenberg 1/5 self-adaptive hill-climb), **not** a bit-exact
+//! replay of the CPU search — the gate is PSNR-within-tolerance vs the CPU run (`gpu3_*_optimize`
+//! tests), exactly as for triangles. Shapes are scored with the parity-exact `score_one_ellipse`/
+//! `score_one_rect` (CORE-3b.2) and committed over the same bbox+inside coverage. All params clamp to
+//! the canvas (radii to `[1, w-1]`), keeping the i32 ellipse test overflow-safe (§6.6) and the search
+//! in fogleman's domain.
+
+use cubecl::prelude::*;
+
+use crate::kernels::{clamp_0_255, clampi, composite, rand_below, rand_u32};
+use crate::score_shapes::{inside_ellipse, score_one_ellipse, score_one_rect};
+use crate::search::residual;
+
+/// Best-of-8 energy-targeted anchor: returns the highest-residual of 8 random pixels (the restart
+/// bias toward error-heavy regions). Advances `ctr` by 16 (2 draws × 8 samples).
+#[cube]
+fn anchor(
+    target: &Array<i32>,
+    current: &Array<i32>,
+    s: u32,
+    ctr: &mut u32,
+    width: i32,
+    height: i32,
+    ax: &mut i32,
+    ay: &mut i32,
+) {
+    let mut x0 = rand_below(s, *ctr, width as u32) as i32;
+    *ctr += 1;
+    let mut y0 = rand_below(s, *ctr, height as u32) as i32;
+    *ctr += 1;
+    let mut e_best = residual(target, current, x0, y0, width);
+    for _ in 0..7 {
+        let qx = rand_below(s, *ctr, width as u32) as i32;
+        *ctr += 1;
+        let qy = rand_below(s, *ctr, height as u32) as i32;
+        *ctr += 1;
+        let qe = residual(target, current, qx, qy, width);
+        if qe > e_best {
+            e_best = qe;
+            x0 = qx;
+            y0 = qy;
+        }
+    }
+    *ax = x0;
+    *ay = y0;
+}
+
+/// CORE-3b.3: one independent ellipse hill-climb per worker. Energy-anchored centre + small random
+/// radii, then `age` Rechenberg-adaptive perturbations of one of `{cx, cy, rx, ry}` (clamped to the
+/// canvas; radii ≥ 1), keeping a change only if it lowers the delta-SSE. Writes best delta + best
+/// `[cx, cy, rx, ry]`; a following `commit_ellipse` composites the step winner.
+#[cube(launch_unchecked)]
+pub fn evolve_ellipse(
+    target: &Array<i32>,
+    current: &Array<i32>,
+    seed: u32,
+    step: u32,
+    alpha: i32,
+    width: i32,
+    height: i32,
+    age: u32,
+    best_delta: &mut Array<i32>,
+    best_ell: &mut Array<i32>,
+) {
+    let w = ABSOLUTE_POS;
+    if w < best_delta.len() {
+        let s = rand_u32(seed + step, w as u32);
+        let mut ctr = 1u32;
+        let mut cx = 0i32;
+        let mut cy = 0i32;
+        anchor(
+            target, current, s, &mut ctr, width, height, &mut cx, &mut cy,
+        );
+        let mut rx = rand_below(s, ctr, 16) as i32 + 1;
+        ctr += 1;
+        let mut ry = rand_below(s, ctr, 16) as i32 + 1;
+        ctr += 1;
+
+        let mut best = score_one_ellipse(target, current, cx, cy, rx, ry, alpha, width, height);
+        let mut span = 10u32;
+        for _it in 0..age {
+            let v = rand_below(s, ctr, 4);
+            ctr += 1;
+            let d = rand_below(s, ctr, 2 * span + 1) as i32 - span as i32;
+            ctr += 1;
+            let mut ncx = cx;
+            let mut ncy = cy;
+            let mut nrx = rx;
+            let mut nry = ry;
+            if v == 0 {
+                ncx = clampi(ncx + d, 0, width - 1);
+            } else if v == 1 {
+                ncy = clampi(ncy + d, 0, height - 1);
+            } else if v == 2 {
+                nrx = clampi(nrx + d, 1, width - 1);
+            } else {
+                nry = clampi(nry + d, 1, height - 1);
+            }
+            let dl = score_one_ellipse(target, current, ncx, ncy, nrx, nry, alpha, width, height);
+            if dl < best {
+                best = dl;
+                cx = ncx;
+                cy = ncy;
+                rx = nrx;
+                ry = nry;
+                span += 4u32;
+                if span > 20u32 {
+                    span = 20u32;
+                }
+            } else if span > 2u32 {
+                span -= 1u32;
+            }
+        }
+
+        best_delta[w] = best;
+        let b = w * 4;
+        best_ell[b] = cx;
+        best_ell[b + 1] = cy;
+        best_ell[b + 2] = rx;
+        best_ell[b + 3] = ry;
+    }
+}
+
+/// CORE-3b.3: one independent rectangle hill-climb per worker. Energy-anchored first corner + a small
+/// random opposite corner, then `age` Rechenberg-adaptive perturbations of one of the four corner
+/// coordinates (clamped to the canvas). Writes best delta + best `[x1, y1, x2, y2]`.
+#[cube(launch_unchecked)]
+pub fn evolve_rect(
+    target: &Array<i32>,
+    current: &Array<i32>,
+    seed: u32,
+    step: u32,
+    alpha: i32,
+    width: i32,
+    height: i32,
+    age: u32,
+    best_delta: &mut Array<i32>,
+    best_rect: &mut Array<i32>,
+) {
+    let w = ABSOLUTE_POS;
+    if w < best_delta.len() {
+        let s = rand_u32(seed + step, w as u32);
+        let mut ctr = 1u32;
+        let mut x1 = 0i32;
+        let mut y1 = 0i32;
+        anchor(
+            target, current, s, &mut ctr, width, height, &mut x1, &mut y1,
+        );
+        let mut x2 = clampi(x1 + rand_below(s, ctr, 16) as i32 + 1, 0, width - 1);
+        ctr += 1;
+        let mut y2 = clampi(y1 + rand_below(s, ctr, 16) as i32 + 1, 0, height - 1);
+        ctr += 1;
+
+        let mut best = score_one_rect(target, current, x1, y1, x2, y2, alpha, width, height);
+        let mut span = 10u32;
+        for _it in 0..age {
+            let v = rand_below(s, ctr, 4);
+            ctr += 1;
+            let d = rand_below(s, ctr, 2 * span + 1) as i32 - span as i32;
+            ctr += 1;
+            let mut nx1 = x1;
+            let mut ny1 = y1;
+            let mut nx2 = x2;
+            let mut ny2 = y2;
+            if v == 0 {
+                nx1 = clampi(nx1 + d, 0, width - 1);
+            } else if v == 1 {
+                ny1 = clampi(ny1 + d, 0, height - 1);
+            } else if v == 2 {
+                nx2 = clampi(nx2 + d, 0, width - 1);
+            } else {
+                ny2 = clampi(ny2 + d, 0, height - 1);
+            }
+            let dl = score_one_rect(target, current, nx1, ny1, nx2, ny2, alpha, width, height);
+            if dl < best {
+                best = dl;
+                x1 = nx1;
+                y1 = ny1;
+                x2 = nx2;
+                y2 = ny2;
+                span += 4u32;
+                if span > 20u32 {
+                    span = 20u32;
+                }
+            } else if span > 2u32 {
+                span -= 1u32;
+            }
+        }
+
+        best_delta[w] = best;
+        let b = w * 4;
+        best_rect[b] = x1;
+        best_rect[b + 1] = y1;
+        best_rect[b + 2] = x2;
+        best_rect[b + 3] = y2;
+    }
+}
+
+/// CORE-3b.3: composite the step-winning ellipse into `current` in place (argmin over `best_delta`
+/// fused in, first-min tie-break; only commits an improving winner). Closed-form color + 16-bit
+/// premultiplied over-composite over the same bbox+`inside_ellipse` coverage `evolve_ellipse` scored.
+#[cube(launch_unchecked)]
+pub fn commit_ellipse(
+    target: &Array<i32>,
+    current: &mut Array<i32>,
+    best_ell: &Array<i32>,
+    best_delta: &Array<i32>,
+    n_workers: i32,
+    alpha: i32,
+    width: i32,
+    height: i32,
+) {
+    if ABSOLUTE_POS == 0 {
+        let mut bd = best_delta[0];
+        let mut wi = 0i32;
+        for i in 1..n_workers {
+            let v = best_delta[i as usize];
+            if v < bd {
+                bd = v;
+                wi = i;
+            }
+        }
+        if bd < 0 {
+            let b = (wi * 4) as usize;
+            let cx = best_ell[b];
+            let cy = best_ell[b + 1];
+            let rx = best_ell[b + 2];
+            let ry = best_ell[b + 3];
+            let a_coef = 65535 / alpha;
+            let xmin = clampi(cx - rx, 0, width - 1);
+            let xmax = clampi(cx + rx, 0, width - 1);
+            let ymin = clampi(cy - ry, 0, height - 1);
+            let ymax = clampi(cy + ry, 0, height - 1);
+
+            let mut rsum = 0i32;
+            let mut gsum = 0i32;
+            let mut bsum = 0i32;
+            let mut count = 0i32;
+            for py in ymin..ymax + 1 {
+                for px in xmin..xmax + 1 {
+                    if inside_ellipse(cx, cy, rx, ry, px, py) {
+                        let idx = ((py * width + px) * 4) as usize;
+                        rsum += (target[idx] - current[idx]) * a_coef + current[idx] * 257;
+                        gsum +=
+                            (target[idx + 1] - current[idx + 1]) * a_coef + current[idx + 1] * 257;
+                        bsum +=
+                            (target[idx + 2] - current[idx + 2]) * a_coef + current[idx + 2] * 257;
+                        count += 1;
+                    }
+                }
+            }
+            if count > 0 {
+                let r = clamp_0_255((rsum / count) >> 8);
+                let g = clamp_0_255((gsum / count) >> 8);
+                let bb = clamp_0_255((bsum / count) >> 8);
+                let av = alpha as u32;
+                let sr = ((r as u32) | ((r as u32) << 8)) * av / 255;
+                let sg = ((g as u32) | ((g as u32) << 8)) * av / 255;
+                let sb = ((bb as u32) | ((bb as u32) << 8)) * av / 255;
+                let sa = av | (av << 8);
+                let aa = (65535 - sa * 65535 / 65535) * 257;
+                for py in ymin..ymax + 1 {
+                    for px in xmin..xmax + 1 {
+                        if inside_ellipse(cx, cy, rx, ry, px, py) {
+                            let idx = ((py * width + px) * 4) as usize;
+                            current[idx] = composite(current[idx] as u32, sr, aa) as i32;
+                            current[idx + 1] = composite(current[idx + 1] as u32, sg, aa) as i32;
+                            current[idx + 2] = composite(current[idx + 2] as u32, sb, aa) as i32;
+                            current[idx + 3] = composite(current[idx + 3] as u32, sa, aa) as i32;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// CORE-3b.3: composite the step-winning rectangle into `current` in place (argmin fused in; only an
+/// improving winner). Color + over-composite over the sorted, clamped bbox (every bbox pixel inside).
+#[cube(launch_unchecked)]
+pub fn commit_rect(
+    target: &Array<i32>,
+    current: &mut Array<i32>,
+    best_rect: &Array<i32>,
+    best_delta: &Array<i32>,
+    n_workers: i32,
+    alpha: i32,
+    width: i32,
+    height: i32,
+) {
+    if ABSOLUTE_POS == 0 {
+        let mut bd = best_delta[0];
+        let mut wi = 0i32;
+        for i in 1..n_workers {
+            let v = best_delta[i as usize];
+            if v < bd {
+                bd = v;
+                wi = i;
+            }
+        }
+        if bd < 0 {
+            let b = (wi * 4) as usize;
+            let rx1 = best_rect[b];
+            let ry1 = best_rect[b + 1];
+            let rx2 = best_rect[b + 2];
+            let ry2 = best_rect[b + 3];
+            let xa = if rx1 < rx2 { rx1 } else { rx2 };
+            let xb = if rx1 < rx2 { rx2 } else { rx1 };
+            let ya = if ry1 < ry2 { ry1 } else { ry2 };
+            let yb = if ry1 < ry2 { ry2 } else { ry1 };
+            let a_coef = 65535 / alpha;
+            let xmin = clampi(xa, 0, width - 1);
+            let xmax = clampi(xb, 0, width - 1);
+            let ymin = clampi(ya, 0, height - 1);
+            let ymax = clampi(yb, 0, height - 1);
+
+            let mut rsum = 0i32;
+            let mut gsum = 0i32;
+            let mut bsum = 0i32;
+            let mut count = 0i32;
+            for py in ymin..ymax + 1 {
+                for px in xmin..xmax + 1 {
+                    let idx = ((py * width + px) * 4) as usize;
+                    rsum += (target[idx] - current[idx]) * a_coef + current[idx] * 257;
+                    gsum += (target[idx + 1] - current[idx + 1]) * a_coef + current[idx + 1] * 257;
+                    bsum += (target[idx + 2] - current[idx + 2]) * a_coef + current[idx + 2] * 257;
+                    count += 1;
+                }
+            }
+            if count > 0 {
+                let r = clamp_0_255((rsum / count) >> 8);
+                let g = clamp_0_255((gsum / count) >> 8);
+                let bb = clamp_0_255((bsum / count) >> 8);
+                let av = alpha as u32;
+                let sr = ((r as u32) | ((r as u32) << 8)) * av / 255;
+                let sg = ((g as u32) | ((g as u32) << 8)) * av / 255;
+                let sb = ((bb as u32) | ((bb as u32) << 8)) * av / 255;
+                let sa = av | (av << 8);
+                let aa = (65535 - sa * 65535 / 65535) * 257;
+                for py in ymin..ymax + 1 {
+                    for px in xmin..xmax + 1 {
+                        let idx = ((py * width + px) * 4) as usize;
+                        current[idx] = composite(current[idx] as u32, sr, aa) as i32;
+                        current[idx + 1] = composite(current[idx + 1] as u32, sg, aa) as i32;
+                        current[idx + 2] = composite(current[idx + 2] as u32, sb, aa) as i32;
+                        current[idx + 3] = composite(current[idx + 3] as u32, sa, aa) as i32;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/primitive-gpu-cubecl/tests/gpu3_ellipse_optimize.rs
+++ b/crates/primitive-gpu-cubecl/tests/gpu3_ellipse_optimize.rs
@@ -1,0 +1,85 @@
+//! CORE-3b.3 gate: the GPU **ellipse** search loop (`evolve_ellipse` → `commit_ellipse`, fully
+//! on-device) reconstructs as well as the CPU ellipse reference — final PSNR within tolerance. Like
+//! the triangle GPU-3 gate, the two are independent optimizers (the GPU is a native energy-anchored
+//! self-adaptive hill-climb, not a replay of the CPU search), so quality is compared by PSNR, not
+//! pixels. Hardware-independent → unconditional in `make verify`.
+
+use primitive_core::{Canvas, Model, Rng, ShapeType};
+use primitive_gpu_cubecl::{gpu_optimize, OptConfig};
+
+const W: usize = 64;
+const H: usize = 64;
+const ALPHA: i32 = 128;
+const SHAPES: usize = 80;
+/// The GPU native search must land within this many dB of the CPU ellipse reference. Both sides are
+/// deterministic (fixed seeds), so the gap is reproducible — empirically **−0.32 dB** (GPU 33.99 vs
+/// CPU 34.31 on this target); 1.0 dB gives a comfortable margin while still catching a real
+/// quality regression in `evolve_ellipse`/`commit_ellipse`.
+const PSNR_TOL_DB: f64 = 1.0;
+
+fn synthetic_target() -> Canvas {
+    let mut c = Canvas::new(W, H);
+    for y in 0..H {
+        for x in 0..W {
+            let i = (y * W + x) * 4;
+            let (mut r, mut g, mut b) = (
+                (x * 255 / W) as u8,
+                (y * 255 / H) as u8,
+                ((x + y) * 255 / (W + H)) as u8,
+            );
+            if (16..40).contains(&x) && (20..44).contains(&y) {
+                r = 230;
+                g = 40;
+                b = 90;
+            }
+            c.pix[i] = r;
+            c.pix[i + 1] = g;
+            c.pix[i + 2] = b;
+            c.pix[i + 3] = 255;
+        }
+    }
+    c
+}
+
+#[test]
+fn gpu3_ellipse_search_matches_cpu_psnr() {
+    let target = synthetic_target();
+
+    // CPU reference: the fogleman hill-climb fitting ellipses.
+    let mut model = Model::with_average_background(target.clone());
+    let mut rng = Rng::new(1);
+    model.run(ShapeType::Ellipse, ALPHA, SHAPES as i32, &mut rng);
+    let cpu_psnr = model.psnr();
+
+    // Warm up (kernel compile + device init), then the real GPU run.
+    let warm = OptConfig {
+        workers: 64,
+        age: 8,
+        shapes: 2,
+        alpha: ALPHA,
+        seed: 9,
+        shape_type: ShapeType::Ellipse,
+    };
+    let _ = gpu_optimize(&target, &warm);
+
+    let cfg = OptConfig {
+        workers: 10240,
+        age: 9,
+        shapes: SHAPES,
+        alpha: ALPHA,
+        seed: 1,
+        shape_type: ShapeType::Ellipse,
+    };
+    let recon = gpu_optimize(&target, &cfg);
+    let gpu_psnr =
+        primitive_core::psnr_from_score(primitive_core::difference_full(&target, &recon));
+
+    println!(
+        "CORE-3b.3 ellipse search: CPU {cpu_psnr:.2} dB | GPU {gpu_psnr:.2} dB | gap {:.2} dB",
+        gpu_psnr - cpu_psnr
+    );
+    assert!(
+        gpu_psnr >= cpu_psnr - PSNR_TOL_DB,
+        "GPU ellipse search {gpu_psnr:.2} dB is > {PSNR_TOL_DB} dB below CPU {cpu_psnr:.2} dB"
+    );
+}

--- a/crates/primitive-gpu-cubecl/tests/gpu3_optimize.rs
+++ b/crates/primitive-gpu-cubecl/tests/gpu3_optimize.rs
@@ -72,6 +72,7 @@ fn gpu3_end_to_end_meets_throughput_and_psnr_gates() {
         shapes: 2,
         alpha: ALPHA,
         seed: 9,
+        shape_type: ShapeType::Triangle,
     };
     let _ = gpu_optimize(&target, &warm);
 
@@ -83,6 +84,7 @@ fn gpu3_end_to_end_meets_throughput_and_psnr_gates() {
         shapes: SHAPES,
         alpha: ALPHA,
         seed: 1,
+        shape_type: ShapeType::Triangle,
     };
     let t_gpu = Instant::now();
     let recon = gpu_optimize(&target, &cfg);

--- a/crates/primitive-gpu-cubecl/tests/gpu3_rect_optimize.rs
+++ b/crates/primitive-gpu-cubecl/tests/gpu3_rect_optimize.rs
@@ -1,0 +1,81 @@
+//! CORE-3b.3 gate: the GPU **rectangle** search loop (`evolve_rect` → `commit_rect`, fully
+//! on-device) reconstructs as well as the CPU rectangle reference — final PSNR within tolerance.
+//! Independent optimizers (the GPU is a native energy-anchored self-adaptive hill-climb), so quality
+//! is compared by PSNR, not pixels. Hardware-independent → unconditional in `make verify`.
+
+use primitive_core::{Canvas, Model, Rng, ShapeType};
+use primitive_gpu_cubecl::{gpu_optimize, OptConfig};
+
+const W: usize = 64;
+const H: usize = 64;
+const ALPHA: i32 = 128;
+const SHAPES: usize = 80;
+/// Within this many dB of the CPU rectangle reference. Deterministic both sides — see the printed
+/// gap; 1.0 dB margins it while still catching a real regression in `evolve_rect`/`commit_rect`.
+const PSNR_TOL_DB: f64 = 1.0;
+
+fn synthetic_target() -> Canvas {
+    let mut c = Canvas::new(W, H);
+    for y in 0..H {
+        for x in 0..W {
+            let i = (y * W + x) * 4;
+            let (mut r, mut g, mut b) = (
+                (x * 255 / W) as u8,
+                (y * 255 / H) as u8,
+                ((x + y) * 255 / (W + H)) as u8,
+            );
+            if (16..40).contains(&x) && (20..44).contains(&y) {
+                r = 230;
+                g = 40;
+                b = 90;
+            }
+            c.pix[i] = r;
+            c.pix[i + 1] = g;
+            c.pix[i + 2] = b;
+            c.pix[i + 3] = 255;
+        }
+    }
+    c
+}
+
+#[test]
+fn gpu3_rect_search_matches_cpu_psnr() {
+    let target = synthetic_target();
+
+    // CPU reference: the fogleman hill-climb fitting rectangles.
+    let mut model = Model::with_average_background(target.clone());
+    let mut rng = Rng::new(1);
+    model.run(ShapeType::Rectangle, ALPHA, SHAPES as i32, &mut rng);
+    let cpu_psnr = model.psnr();
+
+    let warm = OptConfig {
+        workers: 64,
+        age: 8,
+        shapes: 2,
+        alpha: ALPHA,
+        seed: 9,
+        shape_type: ShapeType::Rectangle,
+    };
+    let _ = gpu_optimize(&target, &warm);
+
+    let cfg = OptConfig {
+        workers: 10240,
+        age: 9,
+        shapes: SHAPES,
+        alpha: ALPHA,
+        seed: 1,
+        shape_type: ShapeType::Rectangle,
+    };
+    let recon = gpu_optimize(&target, &cfg);
+    let gpu_psnr =
+        primitive_core::psnr_from_score(primitive_core::difference_full(&target, &recon));
+
+    println!(
+        "CORE-3b.3 rect search: CPU {cpu_psnr:.2} dB | GPU {gpu_psnr:.2} dB | gap {:.2} dB",
+        gpu_psnr - cpu_psnr
+    );
+    assert!(
+        gpu_psnr >= cpu_psnr - PSNR_TOL_DB,
+        "GPU rect search {gpu_psnr:.2} dB is > {PSNR_TOL_DB} dB below CPU {cpu_psnr:.2} dB"
+    );
+}

--- a/docs/plan/primitive-2026-implementation-goal.md
+++ b/docs/plan/primitive-2026-implementation-goal.md
@@ -44,10 +44,12 @@ is measured against. Nothing downstream is trustworthy without the golden image 
 
 ## Subsequent goal blocks (run each in its own session, in order)
 
-> **Status (2026-06-29):** ✅ CORE-1/2 · ✅ GPU-1/2/3 · ✅ GPU-3 perf pass (self-adaptive step, 519 sps @ 64×64,
-> ~1.9× fogleman) · ✅ GUI-1 (eframe shell + live canvas) · ✅ GUI-2 (all 6 §5A gates green; `make verify` ALL
-> GREEN). **Next → PKG-1 Part A (autonomous), then PKG-1 Part B (interactive credentials).** GPU-4 (CUDA) is
-> a different-machine job (`docs/gpu4-cuda/RUNBOOK.md`). Full ledger: `.agent/PROGRESS.md` + `.agent/EVIDENCE.md`.
+> **Status (2026-06-30):** ✅ CORE-1/2 · ✅ GPU-1/2/3 · ✅ GPU-3 perf pass (self-adaptive step, 519 sps @ 64×64,
+> ~1.9× fogleman) · ✅ GUI-1/2 (all 6 §5A gates green) · ✅ CORE-3 complete (ellipse + rectangle: core + CPU +
+> on-device GPU search + GUI selector — A/B.1/B.2/B.3/C; GPU PSNR within 0.4 dB of CPU) · ✅ PKG-1 Part A
+> (`make bundle` builds + validates `primitive.app`, halts pre-codesign). `make verify` ALL GREEN. **Remaining =
+> interactive / other-machine only** (see the PKG-1 Part A note below). GPU-4 (CUDA) is a different-machine job
+> (`docs/gpu4-cuda/RUNBOOK.md`). Full ledger: `.agent/PROGRESS.md` + `.agent/EVIDENCE.md`.
 >
 > **PKG-1 Part A ✅ DONE (2026-06-29):** `make bundle` builds + validates `primitive.app` (`com.primitive.app`,
 > v0.1.0, flat-triangle icon) and HALTS before codesign — no credentials. **Remaining = interactive/other-machine


### PR DESCRIPTION
## Summary

The whole search now runs **GPU-resident for ellipses and rects**, not just triangles — the GPU-3 triangle loop generalized. **Completes CORE-3b: the GPU fits all three shapes.**

## What's in

New module **`search_shapes.rs`**:
- **`evolve_ellipse`** / **`evolve_rect`** — one independent hill-climb per worker: a shared energy-targeted `anchor` (best-of-8 high-residual pixels) seeds the centre / first corner; small random radii / opposite corner; then `age` **Rechenberg 1/5 self-adaptive** perturbations of one param (`{cx,cy,rx,ry}` / the four corners), each clamped to the canvas (radii to `[1,w-1]` → keeps the i32 ellipse test overflow-safe, §6.6), keep-better, scored by the parity-exact `score_one_ellipse`/`score_one_rect`. Writes best delta + best 4-int params.
- **`commit_ellipse`** / **`commit_rect`** — fused argmin + composite the improving step winner over the bbox+`inside_ellipse` / bbox coverage, in place, no host sync.
- Host: `OptConfig.shape_type` selects the kernel triplet; `gpu_optimize` matches on it (best-param buffer 6 ints for triangle, 4 for ellipse/rect).

## Gate (PSNR within tolerance, hardware-independent → unconditional in `make verify`)

Like GPU-3, the GPU is a **native** optimizer (not a replay of the CPU search), so quality is compared by PSNR, not pixels:
- **`gpu3_ellipse_optimize`** — 80 shapes 64×64: **GPU 33.99 dB vs CPU 34.31, gap −0.32 dB** (≤ 1.0 dB tol).
- **`gpu3_rect_optimize`** — 80 shapes 64×64: **GPU 35.13 dB vs CPU 35.50, gap −0.37 dB**.

## App routing (deliberate)

`runner::gpu_instant` plumbs `cfg.shape_type` into `OptConfig`, but the `should_use_gpu` guard **stays triangle-only by choice** — ellipse/rect keep the CPU path's **SVG export + live streaming** (the raster-only GPU instant mode can't offer those). Offering a GPU fast-preview for the new shapes is now a one-line guard change, left as a UX call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)